### PR TITLE
fix: allow configurable forwarder log prefix

### DIFF
--- a/apps/forwarder/README.md
+++ b/apps/forwarder/README.md
@@ -4,7 +4,7 @@ This serverless application forwards data to an Observe FileDrop. Data is
 forwarded by a lambda in two ways:
 
 - any `s3:ObjectCreated` events trigger a copy from the source bucket to the destination bucket.
-- all events read out of an SQS queue are written to a file in the destination bucket.
+- all messages read out of an SQS queue are written to a file in the destination bucket.
 
 You can use the Observe Forwarder as a cost effective means of loading files
 into Observe or for exporting event streams such as EventBridge or SNS data.

--- a/cmd/forwarder/main.go
+++ b/cmd/forwarder/main.go
@@ -18,11 +18,14 @@ import (
 
 var env struct {
 	DestinationURI string `env:"DESTINATION_URI,required"`
+	LogPrefix      string `env:"LOG_PREFIX,default=forwarder/"`
 	Verbosity      int    `env:"VERBOSITY,default=1"`
 }
 
-var logger logr.Logger
-var handler *forwarder.Handler
+var (
+	logger  logr.Logger
+	handler *forwarder.Handler
+)
 
 func init() {
 	if err := realInit(); err != nil {
@@ -51,6 +54,7 @@ func realInit() error {
 
 	handler, err = forwarder.New(&forwarder.Config{
 		DestinationURI: env.DestinationURI,
+		LogPrefix:      env.LogPrefix,
 		S3Client:       s3client,
 		Logger:         &logger,
 	})

--- a/handlers/forwarder/config.go
+++ b/handlers/forwarder/config.go
@@ -14,7 +14,8 @@ var (
 )
 
 type Config struct {
-	DestinationURI string
+	DestinationURI string // S3 URI to write messages and copy files to
+	LogPrefix      string // prefix used when writing SQS messages to S3
 	S3Client       S3Client
 	Logger         *logr.Logger
 }

--- a/handlers/forwarder/message.go
+++ b/handlers/forwarder/message.go
@@ -60,11 +60,11 @@ func processS3Event(message []byte) (uris []*url.URL) {
 }
 
 type CopyEvent struct {
-	Copy []CopyRecord `"json"`
+	Copy []CopyRecord `json:"copy"`
 }
 
 type CopyRecord struct {
-	URI string `"uri"`
+	URI string `json:"uri"`
 }
 
 func processCopyEvent(message []byte) (uris []*url.URL) {


### PR DESCRIPTION
The forwarder writes all SQS messages processed to a file in the destination S3 bucket. Make the S3 prefix we use configurable (default is `forwarder/`).

I also took the opportunity to use more precise language: SQS handles messages, not events. As a result, we are logging messages, rather than "recording results". I also fixed a few lint issues raised by golangci-lint which had slipped when committing straight to master.