### PR TITLE
feat: matrix job to do aws region based releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -76,7 +76,6 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.actor != 'dependabot[bot]' }}
     strategy:
-      fail-fast: false
       matrix:
         region: ${{fromJson(needs.fetch-regions.outputs.matrix)}}
     permissions:


### PR DESCRIPTION
broke the workflow into three jobs:

- fetch regions (saves an aws region list)
- github release (saves the release version)

followed by a matrix job that does the appropriate release to every region

replaces https://github.com/observeinc/aws-sam-testing/pull/10

[sample run](https://github.com/observeinc/colin-aws-sam-testing/actions/runs/6499601835) -- the failures are expected my test bucket only exists in two regions
![image](https://github.com/observeinc/aws-sam-testing/assets/131207535/5a4409ae-0c4c-4b08-8d35-8184144fb477)
