### PR TITLE
chore: adjust so sam-package is development environment friendly

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,9 @@ on:
       - main
   workflow_dispatch:
 
+env:
+  S3_BUCKET_PREFIX: observeinc
+
 jobs:
   fetch-regions:
     runs-on: ubuntu-latest
@@ -100,21 +103,21 @@ jobs:
       run: aws sts get-caller-identity
 
     - name: aws sam release (versioned)
-      run: make sam-package-all
+      run: make release-all
       env:
         VERSION: ${{ needs.github-release.outputs.VERSION }}
         AWS_REGION: ${{ matrix.region }}
 
     - name: aws sam release (beta)
       if: github.event_name == 'push'
-      run: make sam-package-all
+      run: make release-all
       env:
         VERSION: beta
         AWS_REGION: ${{ matrix.region }}
 
     - name: aws sam release (stable)
       if: github.event_name == 'workflow_dispatch'
-      run: make sam-package-all
+      run: make release-all
       env:
         VERSION: latest
         AWS_REGION: ${{ matrix.region }}


### PR DESCRIPTION
an alternative to https://github.com/observeinc/aws-sam-testing/pull/20 that makes `sam-package` developer environment friendly.

The default behaviour is `S3_BUCKET_PREFIX` is defined but empty which means we run `sam package` with `--resolve-s3`.

If however `S3_BUCKET_PREFIX` is defined we're doing a "release"