### PR TITLE
feat: add event router

### DIFF
--- a/handlers/router/router.go
+++ b/handlers/router/router.go
@@ -1,0 +1,92 @@
+package router
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"sync"
+)
+
+var (
+	ErrNoHandler                = errors.New("no handler found")
+	ErrHandlerType              = errors.New("handler must be a function")
+	ErrHandlerAlreadyRegistered = errors.New("already registered")
+	ErrHandlerArgsCount         = errors.New("handler must take 2 arguments")
+	ErrHandlerRequireContext    = errors.New("first argument must be a context")
+	ErrHandlerReturnCount       = errors.New("handler must return 2 values")
+	ErrHandlerRequireError      = errors.New("last return value must be an error")
+)
+
+type Router struct {
+	handlers map[reflect.Type]reflect.Value
+	sync.Mutex
+}
+
+// Register a lambda handler.
+func (r *Router) Register(fs ...any) error {
+	r.Lock()
+	defer r.Unlock()
+	for _, f := range fs {
+		handler := reflect.ValueOf(f)
+		handlerType := reflect.TypeOf(f)
+		if k := handlerType.Kind(); k != reflect.Func {
+			return fmt.Errorf("handler kind %s: %w", k, ErrHandlerType)
+		}
+
+		if n := handlerType.NumIn(); n != 2 {
+			return ErrHandlerArgsCount
+		}
+
+		if t := handlerType.In(0); !t.Implements(reflect.TypeOf((*context.Context)(nil)).Elem()) {
+			return ErrHandlerRequireContext
+		}
+
+		if n := handlerType.NumOut(); n != 2 {
+			return ErrHandlerReturnCount
+		}
+
+		if t := handlerType.Out(1); !t.Implements(reflect.TypeOf((*error)(nil)).Elem()) {
+			return ErrHandlerRequireError
+		}
+
+		eventType := handlerType.In(handlerType.NumIn() - 1)
+		if _, ok := r.handlers[eventType]; ok {
+			return fmt.Errorf("event type %s: %w", eventType, ErrHandlerAlreadyRegistered)
+		}
+
+		r.handlers[eventType] = handler
+	}
+	return nil
+}
+
+func (r *Router) Handle(ctx context.Context, v json.RawMessage) (json.RawMessage, error) {
+	for eventType, handler := range r.handlers {
+		event := reflect.New(eventType)
+
+		if err := json.Unmarshal(v, event.Interface()); err != nil {
+			// assume event was destined for a different handler
+			continue
+		}
+
+		response := handler.Call([]reflect.Value{reflect.ValueOf(ctx), event.Elem()})
+
+		if errVal, ok := response[1].Interface().(error); ok && errVal != nil {
+			return nil, errVal
+		}
+
+		data, err := json.Marshal(response[0].Interface())
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal response: %w", err)
+		}
+		return json.RawMessage(data), nil
+	}
+	return nil, ErrNoHandler
+}
+
+func New() *Router {
+	return &Router{
+		handlers: make(map[reflect.Type]reflect.Value),
+	}
+}

--- a/handlers/router/router_test.go
+++ b/handlers/router/router_test.go
@@ -1,0 +1,127 @@
+package router_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
+	"github.com/observeinc/aws-sam-testing/handlers/router"
+)
+
+func TestRouter(t *testing.T) {
+	t.Parallel()
+	testcases := []struct {
+		Handlers []any
+		Checks   map[string]string
+	}{
+		{
+			Handlers: []any{
+				func(_ context.Context, _ string) (string, error) { return "string", nil },
+				func(_ context.Context, _ int) (string, error) { return "int", nil },
+				func(_ context.Context, _ struct{ V string }) (string, error) { return "custom", nil },
+			},
+			Checks: map[string]string{
+				`1`:             `"int"`,
+				`"1"`:           `"string"`,
+				`{"v": "test"}`: `"custom"`,
+			},
+		},
+	}
+
+	for i, tc := range testcases {
+		tc := tc
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			t.Parallel()
+			r := router.New()
+
+			if err := r.Register(tc.Handlers...); err != nil {
+				t.Fatal(err)
+			}
+
+			for input, output := range tc.Checks {
+				result, err := r.Handle(context.Background(), json.RawMessage(input))
+				if err != nil {
+					t.Fatalf("failed to validate %s: %s", input, err)
+				}
+
+				if string(result) != output {
+					t.Fatalf("mismatched return value for %s", input)
+				}
+			}
+		})
+	}
+}
+
+func TestRouterErrors(t *testing.T) {
+	t.Parallel()
+
+	testcases := []struct {
+		Handlers  []any
+		ExpectErr error
+	}{
+		{
+			// no handlers, no problem
+		},
+		{
+			Handlers: []any{
+				"1",
+			},
+			ExpectErr: router.ErrHandlerType,
+		},
+		{
+			Handlers: []any{
+				func() {},
+			},
+			ExpectErr: router.ErrHandlerArgsCount,
+		},
+		{
+			Handlers: []any{
+				func(int, int) {},
+			},
+			ExpectErr: router.ErrHandlerRequireContext,
+		},
+		{
+			Handlers: []any{
+				func(context.Context, int) {},
+			},
+			ExpectErr: router.ErrHandlerReturnCount,
+		},
+		{
+			Handlers: []any{
+				func(context.Context, int) (int, int) { return 1, 1 },
+			},
+			ExpectErr: router.ErrHandlerRequireError,
+		},
+		{
+			Handlers: []any{
+				func(context.Context, int) (int, error) { return 1, nil },
+				func(context.Context, int) (int, error) { return 1, nil },
+			},
+			ExpectErr: router.ErrHandlerAlreadyRegistered,
+		},
+		{
+			Handlers: []any{
+				func(context.Context, string) (int, error) { return 1, nil },
+				func(context.Context, int) (int, error) { return 1, nil },
+				func(context.Context, float64) (int, error) { return 1, nil },
+			},
+		},
+	}
+
+	for i, tc := range testcases {
+		tc := tc
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			t.Parallel()
+			r := router.New()
+
+			err := r.Register(tc.Handlers...)
+			if diff := cmp.Diff(err, tc.ExpectErr, cmpopts.EquateErrors()); diff != "" {
+				t.Error("unexpected error", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
We will want to build lambda functions that handle different types of events. Rather than reinvent the logic in each handler, this commit introduces a router that attempts to invoke the correct handler by attempting to unmarshal inbound data according to the handler arguments.