### PR TITLE
fix: use mux for forwarder, break out test package

### DIFF
--- a/handler/forwarder/config_test.go
+++ b/handler/forwarder/config_test.go
@@ -4,10 +4,11 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/observeinc/aws-sam-testing/handler/forwarder"
-
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+
+	"github.com/observeinc/aws-sam-testing/handler/forwarder"
+	"github.com/observeinc/aws-sam-testing/handler/handlertest"
 )
 
 func TestConfig(t *testing.T) {
@@ -24,13 +25,13 @@ func TestConfig(t *testing.T) {
 		{
 			Config: forwarder.Config{
 				DestinationURI: "s3://test",
-				S3Client:       &MockS3Client{},
+				S3Client:       &handlertest.S3Client{},
 			},
 		},
 		{
 			Config: forwarder.Config{
 				DestinationURI: "https://example.com",
-				S3Client:       &MockS3Client{},
+				S3Client:       &handlertest.S3Client{},
 			},
 			ExpectError: forwarder.ErrInvalidDestination,
 		},

--- a/handler/forwarder/handler.go
+++ b/handler/forwarder/handler.go
@@ -116,25 +116,25 @@ func (h *Handler) Handle(ctx context.Context, request events.SQSEvent) (response
 	return response, nil
 }
 
-func New(cfg *Config) (*Handler, error) {
+func New(cfg *Config) (h *Handler, err error) {
 	if err := cfg.Validate(); err != nil {
 		return nil, err
 	}
 
 	u, _ := url.ParseRequestURI(cfg.DestinationURI)
 
-	h := &Handler{
+	h = &Handler{
 		DestinationURI: u,
 		LogPrefix:      cfg.LogPrefix,
 		S3Client:       cfg.S3Client,
 	}
 
 	if cfg.Logger != nil {
-		h.Logger = *cfg.Logger
+		h.Mux.Logger = *cfg.Logger
 	}
 
-	if err := h.Register(h.Handle); err != nil {
-		return nil, fmt.Errorf("failed to register handler: %w", err)
+	if err := h.Mux.Register(h.Handle); err != nil {
+		return nil, fmt.Errorf("failed to register functions: %w", err)
 	}
 
 	return h, nil

--- a/handler/forwarder/handler_test.go
+++ b/handler/forwarder/handler_test.go
@@ -19,26 +19,8 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 
 	"github.com/observeinc/aws-sam-testing/handler/forwarder"
+	"github.com/observeinc/aws-sam-testing/handler/handlertest"
 )
-
-type MockS3Client struct {
-	CopyObjectFunc func(context.Context, *s3.CopyObjectInput, ...func(*s3.Options)) (*s3.CopyObjectOutput, error)
-	PutObjectFunc  func(context.Context, *s3.PutObjectInput, ...func(*s3.Options)) (*s3.PutObjectOutput, error)
-}
-
-func (c *MockS3Client) CopyObject(ctx context.Context, params *s3.CopyObjectInput, optFns ...func(*s3.Options)) (*s3.CopyObjectOutput, error) {
-	if c.CopyObjectFunc == nil {
-		return nil, nil
-	}
-	return c.CopyObjectFunc(ctx, params, optFns...)
-}
-
-func (c *MockS3Client) PutObject(ctx context.Context, params *s3.PutObjectInput, optFns ...func(*s3.Options)) (*s3.PutObjectOutput, error) {
-	if c.PutObjectFunc == nil {
-		return nil, nil
-	}
-	return c.PutObjectFunc(ctx, params, optFns...)
-}
 
 func TestCopy(t *testing.T) {
 	t.Parallel()
@@ -124,7 +106,7 @@ func TestHandler(t *testing.T) {
 			RequestFile: "testdata/event.json",
 			Config: forwarder.Config{
 				DestinationURI: "s3://my-bucket",
-				S3Client: &MockS3Client{
+				S3Client: &handlertest.S3Client{
 					CopyObjectFunc: func(ctx context.Context, params *s3.CopyObjectInput, optFns ...func(*s3.Options)) (*s3.CopyObjectOutput, error) {
 						return nil, errSentinel
 					},
@@ -141,7 +123,7 @@ func TestHandler(t *testing.T) {
 			RequestFile: "testdata/event.json",
 			Config: forwarder.Config{
 				DestinationURI: "s3://my-bucket",
-				S3Client: &MockS3Client{
+				S3Client: &handlertest.S3Client{
 					PutObjectFunc: func(ctx context.Context, params *s3.PutObjectInput, optFns ...func(*s3.Options)) (*s3.PutObjectOutput, error) {
 						return nil, errSentinel
 					},

--- a/handler/handlertest/s3.go
+++ b/handler/handlertest/s3.go
@@ -1,0 +1,26 @@
+package handlertest
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+type S3Client struct {
+	CopyObjectFunc func(context.Context, *s3.CopyObjectInput, ...func(*s3.Options)) (*s3.CopyObjectOutput, error)
+	PutObjectFunc  func(context.Context, *s3.PutObjectInput, ...func(*s3.Options)) (*s3.PutObjectOutput, error)
+}
+
+func (c *S3Client) CopyObject(ctx context.Context, params *s3.CopyObjectInput, optFns ...func(*s3.Options)) (*s3.CopyObjectOutput, error) {
+	if c.CopyObjectFunc == nil {
+		return nil, nil
+	}
+	return c.CopyObjectFunc(ctx, params, optFns...)
+}
+
+func (c *S3Client) PutObject(ctx context.Context, params *s3.PutObjectInput, optFns ...func(*s3.Options)) (*s3.PutObjectOutput, error) {
+	if c.PutObjectFunc == nil {
+		return nil, nil
+	}
+	return c.PutObjectFunc(ctx, params, optFns...)
+}


### PR DESCRIPTION
This is a small refactor to use the handler mux in the forwarder and break out the mock utilitiy into a separate package.