### PR TITLE
ci(dependabot): group aws sdk dependencies

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,6 +5,10 @@ updates:
     directory: "/"
     schedule:
       interval: daily
+    groups:
+      github.com/aws/aws-sdk-go-v2:
+        patterns:
+          - "github.com/aws/aws-sdk-go-v2*"
   - package-ecosystem: "terraform"
     directory: "/infrastructure/"
     schedule:


### PR DESCRIPTION
This is my understanding of how we might group all AWS SDK dependencies into a single PR.