### PR TITLE
feat(subscriber): break out request types

### DIFF
--- a/docs/subscriber.md
+++ b/docs/subscriber.md
@@ -1,0 +1,6 @@
+# Observe Subscriber
+
+The subscriber stack subscribes CloudWatch Log Groups to a supported destination ARN (either Kinesis Firehose or Lambda). It supports two request types:
+
+- subscription requests contain a list of log groups which we wish to subscribe to our destination.
+- discovery requests contain a list of filters which are used to generate subscription requests.

--- a/handler/subscriber/handler.go
+++ b/handler/subscriber/handler.go
@@ -2,13 +2,15 @@ package subscriber
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
-	"github.com/go-logr/logr"
 
 	"github.com/observeinc/aws-sam-testing/handler"
 )
+
+var ErrNotImplemented = errors.New("not implemented")
 
 type CloudWatchLogsClient interface {
 	DescribeLogGroups(context.Context, *cloudwatchlogs.DescribeLogGroupsInput, ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.DescribeLogGroupsOutput, error)
@@ -25,54 +27,43 @@ type Handler struct {
 	Client CloudWatchLogsClient
 }
 
-type SyncRequest struct {
-	*SyncConfig `json:"sync"`
-}
+func (h *Handler) HandleDiscoveryRequest(ctx context.Context, discoveryReq *DiscoveryRequest) (*Response, error) {
+	var discoveryResp DiscoveryResponse
 
-type SyncConfig struct {
-	Subscription *cloudwatchlogs.PutSubscriptionFilterInput `json:"subscription,omitempty"`
-	Limit        *int32                                     `json:"limit,omitempty"`
-}
+	for _, input := range discoveryReq.ToDescribeLogInputs() {
+		paginator := cloudwatchlogs.NewDescribeLogGroupsPaginator(h.Client, input)
 
-type task struct {
-	PutSubscriptionFilterInput *cloudwatchlogs.PutSubscriptionFilterInput `json:"subscription,omitempty"`
-	DescribeLogGroupsOutput    *cloudwatchlogs.DescribeLogGroupsOutput    `json:"logGroups"`
-}
-
-type SyncResponse struct {
-	LogGroupCount int `json:"logGroupCount"`
-	PageCount     int `json:"pageCount"`
-}
-
-func (h *Handler) HandleSync(ctx context.Context, request SyncRequest) (*SyncResponse, error) {
-	logger := logr.FromContextOrDiscard(ctx)
-
-	paginator := cloudwatchlogs.NewDescribeLogGroupsPaginator(h.Client, &cloudwatchlogs.DescribeLogGroupsInput{
-		Limit: request.Limit,
-	})
-
-	var response SyncResponse
-
-	for paginator.HasMorePages() {
-		output, err := paginator.NextPage(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("failed to describe log groups: %w", err)
-		}
-
-		response.PageCount++
-		response.LogGroupCount += len(output.LogGroups)
-
-		logger.V(6).Info("queueing page")
-
-		if err := h.Queue.Put(ctx, &task{
-			PutSubscriptionFilterInput: request.Subscription,
-			DescribeLogGroupsOutput:    output,
-		}); err != nil {
-			return nil, fmt.Errorf("failed to queue log groups: %w", err)
+		for paginator.HasMorePages() {
+			page, err := paginator.NextPage(ctx)
+			if err != nil {
+				return nil, fmt.Errorf("failed to describe log groups: %w", err)
+			}
+			discoveryResp.RequestCount++
+			discoveryResp.LogGroupCount += len(page.LogGroups)
 		}
 	}
 
-	return &response, nil
+	return &Response{DiscoveryResponse: &discoveryResp}, nil
+}
+
+func (h *Handler) HandleSubscriptionRequest(_ context.Context, _ *SubscriptionRequest) (*Response, error) {
+	// to be implemented
+	return nil, nil
+}
+
+func (h *Handler) HandleRequest(ctx context.Context, req *Request) (*Response, error) {
+	if err := req.Validate(); err != nil {
+		return nil, fmt.Errorf("failed to validate request: %w", err)
+	}
+
+	switch {
+	case req.DiscoveryRequest != nil:
+		return h.HandleDiscoveryRequest(ctx, req.DiscoveryRequest)
+	case req.SubscriptionRequest != nil:
+		return h.HandleSubscriptionRequest(ctx, req.SubscriptionRequest)
+	default:
+		return nil, ErrNotImplemented
+	}
 }
 
 func New(cfg *Config) (*Handler, error) {
@@ -89,7 +80,7 @@ func New(cfg *Config) (*Handler, error) {
 		h.Logger = *cfg.Logger
 	}
 
-	if err := h.Mux.Register(h.HandleSync); err != nil {
+	if err := h.Mux.Register(h.HandleRequest); err != nil {
 		return nil, fmt.Errorf("failed to register handler: %w", err)
 	}
 

--- a/handler/subscriber/handler_test.go
+++ b/handler/subscriber/handler_test.go
@@ -2,8 +2,13 @@ package subscriber_test
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
+	"github.com/google/go-cmp/cmp"
 
 	"github.com/observeinc/aws-sam-testing/handler/handlertest"
 	"github.com/observeinc/aws-sam-testing/handler/subscriber"
@@ -21,12 +26,119 @@ func (m *MockQueue) Put(_ context.Context, vs ...any) error {
 	return nil
 }
 
-func TestHandler(t *testing.T) {
-	_, err := subscriber.New(&subscriber.Config{
-		CloudWatchLogsClient: &handlertest.CloudWatchLogsClient{},
-		Queue:                &MockQueue{},
-	})
-	if err != nil {
-		t.Fatal(err)
+func TestHandleDiscovery(t *testing.T) {
+	t.Parallel()
+
+	client := &handlertest.CloudWatchLogsClient{
+		LogGroups: []types.LogGroup{
+			{LogGroupName: aws.String("/aws/hello")},
+			{LogGroupName: aws.String("/aws/ello")},
+			{LogGroupName: aws.String("/aws/hola")},
+		},
+		SubscriptionFilters: []types.SubscriptionFilter{
+			{LogGroupName: aws.String("/aws/hello")},
+		},
+	}
+
+	testcases := []struct {
+		DiscoveryRequest *subscriber.DiscoveryRequest
+		ExpectResponse   *subscriber.Response
+	}{
+		{
+			DiscoveryRequest: &subscriber.DiscoveryRequest{},
+			/* matches:
+			- /aws/hello
+			- /aws/ello
+			- /aws/hola
+			*/
+			ExpectResponse: &subscriber.Response{
+				DiscoveryResponse: &subscriber.DiscoveryResponse{
+					RequestCount:  1,
+					LogGroupCount: 3,
+				},
+			},
+		},
+		{
+			DiscoveryRequest: &subscriber.DiscoveryRequest{
+				LogGroupNamePrefixes: []*string{
+					aws.String("/aws/he"),
+					aws.String("/aws/ho"),
+				},
+			},
+			/* matches:
+			- /aws/hello
+			- /aws/hola
+			*/
+			ExpectResponse: &subscriber.Response{
+				DiscoveryResponse: &subscriber.DiscoveryResponse{
+					RequestCount:  2,
+					LogGroupCount: 2,
+				},
+			},
+		},
+		{
+			DiscoveryRequest: &subscriber.DiscoveryRequest{
+				LogGroupNamePatterns: []*string{
+					aws.String("ello"),
+					aws.String("foo"),
+					aws.String("bar"),
+				},
+			},
+			/* matches:
+			- /aws/hello
+			- /aws/ello
+			*/
+			ExpectResponse: &subscriber.Response{
+				DiscoveryResponse: &subscriber.DiscoveryResponse{
+					RequestCount:  3,
+					LogGroupCount: 2,
+				},
+			},
+		},
+		{
+			DiscoveryRequest: &subscriber.DiscoveryRequest{
+				LogGroupNamePatterns: []*string{
+					aws.String("ello"),
+				},
+				LogGroupNamePrefixes: []*string{
+					aws.String("/aws/he"),
+				},
+			},
+			/* matches:
+			- /aws/hello
+			- /aws/ello
+			- /aws/hello
+			*/
+			ExpectResponse: &subscriber.Response{
+				DiscoveryResponse: &subscriber.DiscoveryResponse{
+					RequestCount:  2,
+					LogGroupCount: 3,
+				},
+			},
+		},
+	}
+
+	for i, tt := range testcases {
+		tt := tt
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			t.Parallel()
+
+			s, err := subscriber.New(&subscriber.Config{
+				CloudWatchLogsClient: client,
+				Queue:                &MockQueue{},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			resp, err := s.HandleDiscoveryRequest(context.Background(), tt.DiscoveryRequest)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tt.ExpectResponse, resp); diff != "" {
+				t.Error(diff)
+			}
+		})
 	}
 }

--- a/handler/subscriber/request.go
+++ b/handler/subscriber/request.go
@@ -1,0 +1,96 @@
+package subscriber
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
+)
+
+var ErrMalformedRequest = errors.New("malformed request")
+
+// Request for our handler.
+type Request struct {
+	*SubscriptionRequest `json:"subscribe"`
+	*DiscoveryRequest    `json:"discover"`
+}
+
+// Validate verifies request is a union.
+func (r *Request) Validate() error {
+	if r == nil {
+		return fmt.Errorf("%w: nil request", ErrMalformedRequest)
+	}
+
+	var count int
+	if r.SubscriptionRequest != nil {
+		count++
+	}
+	if r.DiscoveryRequest != nil {
+		count++
+	}
+
+	if count == 0 {
+		return fmt.Errorf("%w: empty request", ErrMalformedRequest)
+	}
+
+	if count > 1 {
+		return fmt.Errorf("%w: conflicting requests", ErrMalformedRequest)
+	}
+
+	return nil
+}
+
+// SubscriptionRequest contains a list of log groups to subscribe.
+type SubscriptionRequest struct {
+	// if provided, we can subscribe this set of log group names
+	LogGroups []*LogGroup `json:"logGroups,omitempty"`
+}
+
+// DiscoveryRequest generates a list of log groups to subscribe.
+type DiscoveryRequest struct {
+	// optional filters
+	LogGroupNamePatterns []*string `json:"logGroupNamePatterns,omitempty"`
+	LogGroupNamePrefixes []*string `json:"logGroupNamePrefixes,omitempty"`
+
+	// Limit when pagination list endpoint
+	Limit *int32 `json:"limit,omitempty"`
+}
+
+// LogGroup represents the minimal viable info we need to be able to subscribe
+// to a log group.
+// Once we need to support linked accounts we'll likely need more than just a
+// name.
+type LogGroup struct {
+	LogGroupName string `json:"logGroupName"`
+}
+
+// ToDescribeLogInputs computes the necessary describe-log-groups commands in order to unpack discovery request
+// No attempt is made to dedupe log group names, since subscription is assumed to be idempotent.
+func (d *DiscoveryRequest) ToDescribeLogInputs() (inputs []*cloudwatchlogs.DescribeLogGroupsInput) {
+	if d == nil {
+		return nil
+	}
+
+	for _, pattern := range d.LogGroupNamePatterns {
+		inputs = append(inputs, &cloudwatchlogs.DescribeLogGroupsInput{
+			LogGroupNamePattern: pattern,
+			Limit:               d.Limit,
+		})
+	}
+
+	for _, prefix := range d.LogGroupNamePrefixes {
+		inputs = append(inputs, &cloudwatchlogs.DescribeLogGroupsInput{
+			LogGroupNamePrefix: prefix,
+			Limit:              d.Limit,
+		})
+	}
+
+	if len(inputs) == 0 {
+		// We should list all since we were provided with no log groups
+		// or filters.
+		inputs = append(inputs, &cloudwatchlogs.DescribeLogGroupsInput{
+			Limit: d.Limit,
+		})
+	}
+	return inputs
+}

--- a/handler/subscriber/request_test.go
+++ b/handler/subscriber/request_test.go
@@ -1,0 +1,56 @@
+package subscriber_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
+	"github.com/observeinc/aws-sam-testing/handler/subscriber"
+)
+
+func TestRequestMalformed(t *testing.T) {
+	t.Parallel()
+
+	testcases := []struct {
+		*subscriber.Request
+		ExpectError error
+	}{
+		{
+			Request:     &subscriber.Request{},
+			ExpectError: subscriber.ErrMalformedRequest,
+		},
+		{
+			Request: &subscriber.Request{
+				SubscriptionRequest: &subscriber.SubscriptionRequest{},
+				DiscoveryRequest:    &subscriber.DiscoveryRequest{},
+			},
+			ExpectError: subscriber.ErrMalformedRequest,
+		},
+		{
+			Request: &subscriber.Request{
+				SubscriptionRequest: &subscriber.SubscriptionRequest{},
+			},
+			ExpectError: nil,
+		},
+		{
+			Request: &subscriber.Request{
+				DiscoveryRequest: &subscriber.DiscoveryRequest{},
+			},
+			ExpectError: nil,
+		},
+	}
+
+	for i, tt := range testcases {
+		tt := tt
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			t.Parallel()
+
+			err := tt.Request.Validate()
+			if diff := cmp.Diff(tt.ExpectError, err, cmpopts.EquateErrors()); diff != "" {
+				t.Error(diff)
+			}
+		})
+	}
+}

--- a/handler/subscriber/response.go
+++ b/handler/subscriber/response.go
@@ -1,0 +1,16 @@
+package subscriber
+
+// Response from our handler.
+type Response struct {
+	*SubscriptionResponse `json:"subscription"`
+	*DiscoveryResponse    `json:"discovery"`
+}
+
+type DiscoveryResponse struct {
+	// RequestCount tracks number of API requests
+	RequestCount int
+	// LogGroupCount tracks count of log groups retrieved from API
+	LogGroupCount int
+}
+
+type SubscriptionResponse struct{}

--- a/integration/scripts/check_subscriber
+++ b/integration/scripts/check_subscriber
@@ -25,7 +25,7 @@ check_result() {
     fi
 }
 
-echo '{"sync": {}}' > ${TMPFILE}
+echo '{"subscribe": {}}' > ${TMPFILE}
 RESULT=$(aws lambda invoke \
     --function-name ${FUNCTION_NAME} \
     --payload fileb://${TMPFILE} ${TMPFILE} \


### PR DESCRIPTION
Flesh out the two types of requests our handler will support. I'm purposely keeping implementation light so as to make reviews more tractable.