### PR TITLE
feat(firehose): allow creation of writer role

### DIFF
--- a/apps/firehose/template.yaml
+++ b/apps/firehose/template.yaml
@@ -44,11 +44,20 @@ Parameters:
     Description: |
       Buffer incoming data to the specified size, in MiBs, before delivering it
       to the destination.
+  WriterRoleService:
+    Type: String
+    Description: |
+      Optional service to create writer role for.
+    Default: ''
 
 Conditions:
   UseStackName: !Equals
     - !Ref NameOverride
     - ''
+  CreateWriterRole: !Not
+    - !Equals
+      - !Ref WriterRoleService
+      - ''
 
 Resources:
   Role:
@@ -125,8 +134,41 @@ Resources:
           Enabled: true
           LogGroupName: !Ref LogGroup
           LogStreamName: !Ref LogStream
+  WriterRole:
+    Type: 'AWS::IAM::Role'
+    Condition: CreateWriterRole
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - !Ref WriterRoleService
+            Action:
+              - 'sts:AssumeRole'
+      Path: /
+      Policies:
+        - PolicyName: firehose
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - firehose:DescribeDeliveryStream
+                  - firehose:ListDeliveryStreams
+                  - firehose:ListTagsForDeliveryStream
+                  - firehose:PutRecord
+                  - firehose:PutRecordBatch
+                Resource: !GetAtt 'DeliveryStream.Arn'
 
 Outputs:
   Firehose:
     Description: 'Firehose ARN'
     Value: !GetAtt 'DeliveryStream.Arn'
+  WriterRole:
+    Description: 'Writer role ARN'
+    Value: !If
+      - CreateWriterRole
+      - !GetAtt 'WriterRole.Arn'
+      - ''

--- a/integration/tests/firehose.tftest.hcl
+++ b/integration/tests/firehose.tftest.hcl
@@ -41,8 +41,9 @@ run "set_prefix" {
     name = run.setup.id
     app  = "firehose"
     parameters = {
-      BucketARN = "arn:aws:s3:::${run.setup.access_point.bucket}"
-      Prefix    = "${run.setup.id}/"
+      BucketARN         = "arn:aws:s3:::${run.setup.access_point.bucket}"
+      Prefix            = "${run.setup.id}/"
+      WriterRoleService = "logs.amazonaws.com"
     }
     capabilities = [
       "CAPABILITY_IAM",


### PR DESCRIPTION
It is convenient to create a role that has access to writing to the firehose we create within our app. We don't necessarily know what service will be assuming the role however. Gate the creation of such a role on the user providing a service.