### PR TITLE
ci: reduce frequency of gomod job

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,7 +4,7 @@ updates:
   - package-ecosystem: gomod
     directory: "/"
     schedule:
-      interval: daily
+      interval: weekly
     groups:
       github.com/aws/aws-sdk-go-v2:
         patterns:


### PR DESCRIPTION
AWS SDK has daily releases, we shouldn't burn review time / CI time on them. Batch things up into weekly changes.