### PR TITLE
feat(subscriber): add ability to consume items from queue

### DIFF
--- a/handler/subscriber/discovery.go
+++ b/handler/subscriber/discovery.go
@@ -47,7 +47,7 @@ func (h *Handler) HandleDiscoveryRequest(ctx context.Context, discoveryReq *Disc
 					return resp, fmt.Errorf("failed to handle subscription request: %w", err)
 				}
 				resp.Discovery.Subscription.Add(s.Subscription)
-			} else if err := h.Queue.Put(ctx, subscriptionRequest); err != nil {
+			} else if err := h.Queue.Put(ctx, &Request{SubscriptionRequest: subscriptionRequest}); err != nil {
 				return resp, fmt.Errorf("failed to write to queue: %w", err)
 			}
 		}

--- a/handler/subscriber/handler_test.go
+++ b/handler/subscriber/handler_test.go
@@ -1,0 +1,74 @@
+package subscriber_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/observeinc/aws-sam-testing/handler/handlertest"
+	"github.com/observeinc/aws-sam-testing/handler/subscriber"
+)
+
+func TestHandleSQS(t *testing.T) {
+	t.Parallel()
+
+	testcases := []struct {
+		Event  events.SQSEvent
+		Expect events.SQSEventResponse
+	}{
+		{
+			Event: events.SQSEvent{
+				Records: []events.SQSMessage{
+					{
+						MessageId: "invalid request",
+						Body:      "",
+					},
+				},
+			},
+			Expect: events.SQSEventResponse{
+				BatchItemFailures: []events.SQSBatchItemFailure{
+					{ItemIdentifier: "invalid request"},
+				},
+			},
+		},
+		{
+			Event: events.SQSEvent{
+				Records: []events.SQSMessage{
+					{
+						MessageId: "ok",
+						Body:      "{\"subscribe\": {\"logGroups\":[{\"logGroupName\":\"/aws/hello\"}]}}",
+					},
+				},
+			},
+			Expect: events.SQSEventResponse{},
+		},
+	}
+
+	for i, tt := range testcases {
+		tt := tt
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			t.Parallel()
+
+			s, err := subscriber.New(&subscriber.Config{
+				CloudWatchLogsClient: &handlertest.CloudWatchLogsClient{},
+				FilterName:           "test",
+				LogGroupNamePrefixes: []string{"*"},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			resp, err := s.HandleSQS(context.Background(), tt.Event)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(resp, tt.Expect); diff != "" {
+				t.Error(diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This adds a handler to process SQS messages. We were previously dumping only subscription requests into the queue. This commit additional makes it so that any request recognized by the handler can also be consumed via the queue.