### PR TITLE
fix(integration): support special characters in exec module

### DIFF
--- a/integration/modules/exec/exec
+++ b/integration/modules/exec/exec
@@ -2,8 +2,8 @@
 set -o pipefail
 # source environment variables from a JSON blob from stdin
 STDIN=$(</dev/stdin)
-ENV=$(echo $STDIN | jq -r "to_entries|map(\"\(.key)=\(.value|tostring)\")|.[]")
-export $ENV
+ENV=$(echo "$STDIN" | jq -r 'to_entries | map("\(.key)=\(.value)") | @sh')
+eval "export ${ENV}"
 
 # if debug file is provided, write out and wait for it to be deleted
 # before proceeding

--- a/integration/modules/exec/variables.tf
+++ b/integration/modules/exec/variables.tf
@@ -14,6 +14,7 @@ variable "args" {
   nullable    = false
   default     = []
 }
+
 variable "env_vars" {
   description = <<-EOF
     Environment variables

--- a/integration/scripts/check_bucket_not_empty
+++ b/integration/scripts/check_bucket_not_empty
@@ -6,4 +6,5 @@ DIE() { echo "$*" 1>&2; exit 1; }
 [[ ! -z "${SOURCE:-}" ]] || DIE "source not set"
 
 echo "listing ${SOURCE}"
-[[ ! -z $(aws s3 ls ${SOURCE}) ]] || DIE "bucket is empty"
+RESULT=$(aws s3 ls ${SOURCE} ${OPTS:-})
+[[ ! -z ${RESULT} ]] || DIE "bucket is empty"

--- a/integration/tests/simple.tftest.hcl
+++ b/integration/tests/simple.tftest.hcl
@@ -13,11 +13,12 @@ run "check" {
     command = "./scripts/check_bucket_not_empty"
     env_vars = {
       SOURCE = run.setup.access_point.bucket
+      OPTS   = "--output json"
     }
   }
 
   assert {
-    condition     = output.exitcode != 0
+    condition     = output.error == "bucket is empty"
     error_message = "Bucket isn't empty"
   }
 }


### PR DESCRIPTION
This commit supports passing in environment variables with special characters to scripts in our "exec" module. The testcase has been modified to exemplify this functionality. Prior to this change, the testcase would fail due the variable getting clobbered after the first argument:

```
aws: error: argument --output: expected one argument
```