### PR TITLE
fix(subscriber): correct ARN validation for IAM role

### DIFF
--- a/handler/subscriber/config.go
+++ b/handler/subscriber/config.go
@@ -74,7 +74,7 @@ func (c *Config) Validate() error {
 		}
 
 		roleARN, err := arn.Parse(c.RoleARN)
-		if err != nil || roleARN.Service != "iam" || strings.HasPrefix(roleARN.Resource, "role/") {
+		if err != nil || roleARN.Service != "iam" || !strings.HasPrefix(roleARN.Resource, "role/") {
 			errs = append(errs, fmt.Errorf("failed to parse role: %w", ErrInvalidARN))
 		}
 	}

--- a/handler/subscriber/config_test.go
+++ b/handler/subscriber/config_test.go
@@ -45,9 +45,18 @@ func TestConfig(t *testing.T) {
 			Config: subscriber.Config{
 				CloudWatchLogsClient: &handlertest.CloudWatchLogsClient{},
 				FilterName:           "observe-logs-subscription",
-				RoleARN:              "arn:aws:lambda:us-east-2:123456789012:function:my-function",
+				RoleARN:              "arn:aws:iam::123456789012:role/test",
 			},
 			ExpectError: subscriber.ErrMissingDestinationARN,
+		},
+
+		{
+			Config: subscriber.Config{
+				CloudWatchLogsClient: &handlertest.CloudWatchLogsClient{},
+				FilterName:           "observe-logs-subscription",
+				DestinationARN:       "arn:aws:firehose:us-west-2:123456789012:deliverystream/test",
+				RoleARN:              "arn:aws:iam::123456789012:role/test",
+			},
 		},
 		{
 			Config: subscriber.Config{


### PR DESCRIPTION
Our logic was busted. It was passing tests because the test fixture had a lambda ARN instead. Provide fix and add a new test for the happy path of a firehose ARN alongside the role ARN.