### PR TITLE
feat(config): allow inclusion and exclusion of resource types

### DIFF
--- a/apps/config/template.yaml
+++ b/apps/config/template.yaml
@@ -32,6 +32,20 @@ Parameters:
     Description: >-
       The ARN of the SNS topic that AWS Config delivers notifications to.
     Default: ""
+  IncludeResourceTypes:
+    Type: CommaDelimitedList
+    Description: >-
+      Restrict configuration collection to a subset of resource types. This
+      parameter is mutually exclusive with ExcludeResourceTypes. If neither
+      IncludeResourceTypes or ExcludeResourceTypes is set, all supported
+      resource types are collected.
+    Default: ""
+  ExcludeResourceTypes:
+    Type: CommaDelimitedList
+    Description: >-
+      Exclude a subset of resource types from configuration collection. This
+      parameter is mutually exclusive with IncludeResourceTypes.
+    Default: ""
   Prefix:
     Type: String
     Description: >-
@@ -52,7 +66,25 @@ Conditions:
   DisableSNS: !Equals
     - !Ref TopicARN
     - ""
-
+  IncludeResources: !Not
+    - !Equals
+      - ''
+      - !Join
+        - ','
+        - !Ref IncludeResourceTypes
+  ExcludeResources: !Not
+    - !Equals
+      - ''
+      - !Join
+        - ','
+        - !Ref ExcludeResourceTypes
+  IncludeAll: !Not
+    - !Or
+      - !Condition IncludeResources
+      - !Condition ExcludeResources
+  # we may want to make this configurable in the future,
+  # but it can only be set for "ALL_SUPPORTED_RESOURCE_TYPES".
+  IncludeGlobal: !Condition IncludeAll
 Resources:
   ConfigurationRecorderRole:
     Type: AWS::IAM::Role
@@ -98,8 +130,30 @@ Resources:
     Properties:
       Name: default
       RecordingGroup:
-        AllSupported: true
-        IncludeGlobalResourceTypes: true
+        AllSupported: !If
+          - IncludeAll
+          - true
+          - false
+        IncludeGlobalResourceTypes: !If
+          - IncludeGlobal
+          - true
+          - false
+        ExclusionByResourceTypes: !If
+          - ExcludeResources
+          - ResourceTypes: !Ref ExcludeResourceTypes
+          - !Ref 'AWS::NoValue'
+        ResourceTypes: !If
+          - IncludeResources
+          - !Ref IncludeResourceTypes
+          - !Ref 'AWS::NoValue'
+        RecordingStrategy:
+          UseOnly: !If
+           - IncludeResources
+           - "INCLUSION_BY_RESOURCE_TYPES"
+           - !If
+            - ExcludeResources
+            - "EXCLUSION_BY_RESOURCE_TYPES"
+            - "ALL_SUPPORTED_RESOURCE_TYPES"
       RoleARN: !GetAtt ConfigurationRecorderRole.Arn
   ConfigurationDeliveryChannel:
     Type: AWS::Config::DeliveryChannel

--- a/docs/config.md
+++ b/docs/config.md
@@ -16,6 +16,8 @@ The following parameters are required for stack configuration:
 | `TopicARN`          | (Optional) The ARN of the SNS topic for AWS Config notifications. If not provided, notifications are disabled. |
 | `Prefix`            | (Optional) The prefix for the S3 bucket where AWS Config stores configuration snapshots. |
 | `DeliveryFrequency` | The frequency at which AWS Config delivers configuration snapshots. Options range from one hour to twenty-four hours. |
+| `IncludeResourceTypes` | Restrict configuration collection to a subset of resource types. This parameter is mutually exclusive with ExcludeResourceTypes. If neither IncludeResourceTypes or ExcludeResourceTypes is set, all supported resource types are collected. |
+| `ExcludeResourceTypes` | Exclude a subset of resource types from configuration collection. This parameter is mutually exclusive with IncludeResourceTypes. |
 
 ## Resources
 

--- a/integration/tests/config.tftest.hcl
+++ b/integration/tests/config.tftest.hcl
@@ -40,3 +40,33 @@ run "check" {
     error_message = "Bucket is empty"
   }
 }
+
+run "install_include" {
+  variables {
+    name = run.setup.id
+    app  = "config"
+    parameters = {
+      BucketName    = run.setup.access_point.bucket
+      IncludeResourceTypes = "AWS::Redshift::ClusterSnapshot,AWS::RDS::DBClusterSnapshot,AWS::CloudFront::StreamingDistribution"
+    }
+    capabilities = [
+      "CAPABILITY_NAMED_IAM",
+      "CAPABILITY_AUTO_EXPAND",
+    ]
+  }
+}
+
+run "install_exclude" {
+  variables {
+    name = run.setup.id
+    app  = "config"
+    parameters = {
+      BucketName    = run.setup.access_point.bucket
+      ExcludeResourceTypes = "AWS::Redshift::ClusterSnapshot,AWS::RDS::DBClusterSnapshot,AWS::CloudFront::StreamingDistribution"
+    }
+    capabilities = [
+      "CAPABILITY_NAMED_IAM",
+      "CAPABILITY_AUTO_EXPAND",
+    ]
+  }
+}


### PR DESCRIPTION
AWS Config allows for the inclusion and exclusion of resource types when setting up the Configuration Recorder. Unfortunately the API is extremely convoluted. This commit surfaces the configuration knobs in a simplified manner.