### PR TITLE
fix(collection): set custom content type for cloudwatch logs

### DIFF
--- a/apps/collection/template.yaml
+++ b/apps/collection/template.yaml
@@ -200,7 +200,10 @@ Resources:
                   - !Join [",", !Ref SourceTopicArns]
         ContentTypeOverrides: !Join
             - ","
-            - !Ref ContentTypeOverrides
+            - - !Sub "s3://${Bucket}/cloudwatchlogs/=application/x-aws-cloudwatchlogs"
+              - !Join
+                - ","
+                - !Ref ContentTypeOverrides
         NameOverride: !If
           - UseStackName
           - !Ref 'AWS::StackName'

--- a/handler/forwarder/overrides.go
+++ b/handler/forwarder/overrides.go
@@ -42,6 +42,13 @@ func (c *contentTypeOverride) Match(s string) string {
 func NewContentTypeOverrides(kvs []string, delimiter string) (Matcher, error) {
 	var m matches
 	for _, pair := range kvs {
+		if pair == "" {
+			// treat empty values as noops
+			// this overcomes a cloudformation limitation in concatenating
+			// multiple values, which can result in trailing commas
+			continue
+		}
+
 		split := strings.SplitN(pair, delimiter, 2)
 		if len(split) != 2 {
 			return nil, fmt.Errorf("error parsing %q: %w", pair, errMissingDelimiter)

--- a/handler/forwarder/overrides_test.go
+++ b/handler/forwarder/overrides_test.go
@@ -13,7 +13,7 @@ func TestContentTypeOverridesErrors(t *testing.T) {
 	t.Parallel()
 
 	testcases := []string{
-		"",
+		"nonono",
 		"\\=",
 	}
 
@@ -40,6 +40,7 @@ func TestContentTypeOverrides(t *testing.T) {
 		{
 			ContentTypeOverrides: []string{
 				".*=application/json",
+				"",
 			},
 			Delimiter: "=",
 			Expect: map[string]string{


### PR DESCRIPTION
CloudWatch logs do not have an inferrable file type. This commit explicitly overrides the content type based on the file name, since we know where the logs will show up. For now, us a custom content type to identify cloudwatch logs. This will allow us to handle this data in a more targeted manner within filedrop.