### PR TITLE
ci: bump golangci timeout

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,3 +1,6 @@
+run:
+  timeout: 10m
+
 linters:
   disable-all: true
   # Disable specific linter


### PR DESCRIPTION
Default timeout is 1m, which now regularly times out in CI.