### PR TITLE
fix(collection): adjust Config parameters

### DIFF
--- a/.github/workflows/tests-integration.yaml
+++ b/.github/workflows/tests-integration.yaml
@@ -7,6 +7,12 @@ on:
   # release.yaml runs the tests on commits to main
   pull_request:
   workflow_dispatch:
+    inputs:
+      debug_enabled:
+        type: boolean
+        description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'
+        required: false
+        default: false
   workflow_call:
   schedule:
     - cron:  '0 0 * * 1' # Monday at 00:00 UTC
@@ -72,6 +78,12 @@ jobs:
       env:
         AWS_REGION: us-west-2
         S3_BUCKET_PREFIX: ${{ github.run_id }}
+
+    - name: Setup tmate session
+      uses: mxschmitt/action-tmate@v3
+      if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
+      with:
+        limit-access-to-actor: true
 
     - name: Archive SAM directory
       uses: actions/upload-artifact@v3

--- a/apps/collection/template.yaml
+++ b/apps/collection/template.yaml
@@ -22,11 +22,12 @@ Metadata:
           - DataAccessPointArn
           - DestinationUri
       - Label:
-          default: Resources
+          default: AWS Config
         Parameters:
-          - InstallConfig
+          - IncludeResourceTypes
+          - ExcludeResourceTypes
       - Label:
-          default: Logs
+          default: CloudWatch Logs
         Parameters:
           - LogGroupNamePatterns
           - LogGroupNamePrefixes
@@ -72,17 +73,19 @@ Parameters:
       Name of IAM role expected by Filedrop. This role will be created as part
       of this stack, and must therefore be unique within the account.
     Default: ""
-  InstallConfig:
-    Type: String
-    AllowedValues:
-      - "true"
-      - "false"
-    Default: "true"
+  IncludeResourceTypes:
+    Type: CommaDelimitedList
     Description: >-
-      Set to `true` to install AWS Config. AWS Config can only be configured
-      once per region. If you already have an existing AWS Config Recorder
-      installed, set this value to `false` and subscribe the S3 bucket
-      containing the configuration snapshots.
+      Resources to collect using AWS Config. Use a wildcard to collect all
+      supported resource types. Do not set this parameter if AWS Config is
+      already installed for this region.
+    Default: ""
+  ExcludeResourceTypes:
+    Type: CommaDelimitedList
+    Description: >-
+      Exclude a subset of resource types from configuration collection. This
+      parameter can only be set if IncludeResourceTypes is wildcarded.
+    Default: ""
   LogGroupNamePatterns:
     Type: CommaDelimitedList
     Description: >-
@@ -98,9 +101,13 @@ Parameters:
     Default: ''
 
 Conditions:
-  EnableConfig: !Equals
-    - !Ref InstallConfig
-    - "true"
+  EnableConfig: !Not
+    - !Equals
+      - ""
+      - !Join [",", !Ref IncludeResourceTypes]
+  IncludeAllResourceTypes: !Equals
+    - "*"
+    - !Join [",", !Ref IncludeResourceTypes]
   EnableSubscriber: !Not
     - !And
       - !Equals
@@ -118,7 +125,6 @@ Conditions:
   EmptySourceTopicArns: !Equals
     - !Join [",", !Ref SourceTopicArns]
     - ""
-
 Resources:
   Topic:
     Type: "AWS::SNS::Topic"
@@ -227,6 +233,11 @@ Resources:
       Parameters:
         BucketName: !Ref Bucket
         TopicARN: !Ref Topic
+        IncludeResourceTypes: !If
+          - IncludeAllResourceTypes
+          - ""
+          - !Join [",", !Ref IncludeResourceTypes]
+        ExcludeResourceTypes: !Join [",", !Ref ExcludeResourceTypes]
   Firehose:
     Type: AWS::Serverless::Application
     Properties:


### PR DESCRIPTION
Update collection stack to make surface include / exclude resource types for AWS Config. As a result of this change, Config is no longer installed by default, which in turn fixes our test issues around multiple tests attempting to install configuration recorders which are per-region singletons.