### PR TITLE
fix: test name override

### DIFF
--- a/apps/collection/template.yaml
+++ b/apps/collection/template.yaml
@@ -67,6 +67,7 @@ Parameters:
       Name of IAM role expected by Filedrop. This role will be created as part
       of this stack, and must therefore be unique within the account.
     Default: ""
+    MaxLength: 52
   IncludeResourceTypes:
     Type: CommaDelimitedList
     Description: >-
@@ -110,11 +111,11 @@ Conditions:
       - !Equals
         - !Join [",", !Ref LogGroupNamePrefixes]
         - ""
-  UseStackName: !Equals
-    - !Ref NameOverride
-    - ""
   EmptySourceBucketNames: !Equals
     - !Join [",", !Ref SourceBucketNames]
+    - ""
+  UseStackName: !Equals
+    - !Ref NameOverride
     - ""
 Resources:
   Topic:
@@ -194,10 +195,7 @@ Resources:
               - !Join
                 - ","
                 - !Ref ContentTypeOverrides
-        NameOverride: !If
-          - UseStackName
-          - !Ref 'AWS::StackName'
-          - !Ref NameOverride
+        NameOverride: !Ref NameOverride
   TopicSubscription:
     Type: AWS::SNS::Subscription
     Properties:
@@ -232,7 +230,10 @@ Resources:
         BucketARN: !GetAtt Bucket.Arn
         Prefix: "cloudwatchlogs/"
         WriterRoleService: "logs.amazonaws.com"
-        NameOverride: !Ref NameOverride
+        NameOverride: !If
+          - UseStackName
+          - !Ref AWS::NoValue
+          - !Sub "${NameOverride}-Firehose"
   Subscriber:
     Type: AWS::Serverless::Application
     Condition: EnableSubscriber
@@ -251,8 +252,10 @@ Resources:
         LogGroupNamePrefixes: !Join [",", !Ref LogGroupNamePrefixes]
         LogGroupNamePatterns: !Join [",", !Ref LogGroupNamePatterns]
         DiscoveryRate: "24 hours"
-        NameOverride: !Ref NameOverride
-
+        NameOverride: !If
+          - UseStackName
+          - !Ref AWS::NoValue
+          - !Sub "${NameOverride}-Subscriber"
 Outputs:
   Bucket:
     Description: "S3 Bucket Name"

--- a/apps/firehose/template.yaml
+++ b/apps/firehose/template.yaml
@@ -28,6 +28,7 @@ Parameters:
       Set Firehose Delivery Stream name. In the absence of a value, the stack
       name will be used.
     Default: ''
+    MaxLength: 64
   BufferingInterval:
     Type: Number
     Default: 60

--- a/apps/forwarder/template.yaml
+++ b/apps/forwarder/template.yaml
@@ -48,6 +48,7 @@ Parameters:
       the SQS Queue and Lambda Function processing events. In the absence of a
       value, the stack name will be used.
     Default: ''
+    MaxLength: 64
   SourceBucketNames:
     Type: CommaDelimitedList
     Description: >-

--- a/apps/metricstream/template.yaml
+++ b/apps/metricstream/template.yaml
@@ -37,6 +37,7 @@ Parameters:
       Set Firehose Delivery Stream name. In the absence of a value, the stack
       name will be used.
     Default: ''
+    MaxLength: 64
   BufferingInterval:
     Type: Number
     Default: 60

--- a/apps/subscriber/template.yaml
+++ b/apps/subscriber/template.yaml
@@ -73,6 +73,7 @@ Parameters:
     Description: >-
       Name of Lambda function.
     Default: ''
+    MaxLength: 64
 
 Conditions:
   SetDefaultFilterName: !Equals

--- a/integration/main.tf
+++ b/integration/main.tf
@@ -1,7 +1,7 @@
 data "aws_region" "current" {}
 
 resource "aws_cloudformation_stack" "this" {
-  name          = var.name
+  name          = var.setup.stack_name
   template_body = file("../.aws-sam/build/${var.app}/${data.aws_region.current.name}/packaged.yaml")
   parameters    = var.parameters
   capabilities  = var.capabilities
@@ -11,7 +11,7 @@ resource "aws_cloudformation_stack" "this" {
 
 resource "aws_iam_role" "this" {
   count       = var.install_policy_json == null ? 0 : 1
-  name_prefix = "${var.name}-"
+  name_prefix = "${var.setup.short}-"
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17",

--- a/integration/modules/setup/run/main.tf
+++ b/integration/modules/setup/run/main.tf
@@ -1,5 +1,15 @@
+locals {
+  stack_name = substr("${random_pet.run.id}-${random_id.suffix.hex}", 0, 128)
+  id         = substr(local.stack_name, 0, var.id_length)
+  short      = substr(local.stack_name, 0, var.short_length)
+}
+
 resource "random_pet" "run" {
   length = 2
+}
+
+resource "random_id" "suffix" {
+  byte_length = 64
 }
 
 data "aws_region" "current" {}

--- a/integration/modules/setup/run/outputs.tf
+++ b/integration/modules/setup/run/outputs.tf
@@ -1,6 +1,16 @@
+output "stack_name" {
+  description = "Random test identifier padded out to 128 characters."
+  value       = local.stack_name
+}
+
 output "id" {
-  description = "Random test identifier"
-  value       = random_pet.run.id
+  description = "Run identifier"
+  value       = local.id
+}
+
+output "short" {
+  description = "Identifier truncated to a shorter length."
+  value       = local.short
 }
 
 output "region" {

--- a/integration/modules/setup/run/variables.tf
+++ b/integration/modules/setup/run/variables.tf
@@ -1,0 +1,11 @@
+variable "id_length" {
+  type        = number
+  default     = 64
+  description = "String length for id."
+}
+
+variable "short_length" {
+  type        = number
+  default     = 32
+  description = "String length for short identifier."
+}

--- a/integration/tests/collection.tftest.hcl
+++ b/integration/tests/collection.tftest.hcl
@@ -115,18 +115,22 @@ EOF
 
 run "setup" {
   module {
-    source = "./modules/setup/run"
+    source    = "./modules/setup/run"
+  }
+  variables {
+    id_length = 52
   }
 }
 
 run "install_collection" {
   variables {
-    name        = "collection-stack-${run.setup.id}"
-    app         = "collection"
+    setup = run.setup
+    app   = "collection"
     parameters  = {
       DataAccessPointArn   = run.setup.access_point.arn
       DestinationUri       = "s3://${run.setup.access_point.alias}"
       LogGroupNamePatterns = "*"
+      NameOverride         = run.setup.id
     }
     capabilities = [
       "CAPABILITY_NAMED_IAM",

--- a/integration/tests/config.tftest.hcl
+++ b/integration/tests/config.tftest.hcl
@@ -48,10 +48,10 @@ run "setup" {
 
 run "install_config" {
   variables {
-    name = run.setup.id
-    app  = "config"
+    setup = run.setup
+    app   = "config"
     parameters = {
-      BucketName = run.setup.access_point.bucket
+      BucketName   = run.setup.access_point.bucket
     }
     capabilities = [
       "CAPABILITY_NAMED_IAM",
@@ -85,10 +85,10 @@ run "check" {
 
 run "install_include" {
   variables {
-    name = run.setup.id
-    app  = "config"
+    setup = run.setup
+    app   = "config"
     parameters = {
-      BucketName    = run.setup.access_point.bucket
+      BucketName           = run.setup.access_point.bucket
       IncludeResourceTypes = "AWS::Redshift::ClusterSnapshot,AWS::RDS::DBClusterSnapshot,AWS::CloudFront::StreamingDistribution"
     }
     capabilities = [
@@ -100,10 +100,10 @@ run "install_include" {
 
 run "install_exclude" {
   variables {
-    name = run.setup.id
+    setup = run.setup
     app  = "config"
     parameters = {
-      BucketName    = run.setup.access_point.bucket
+      BucketName           = run.setup.access_point.bucket
       ExcludeResourceTypes = "AWS::Redshift::ClusterSnapshot,AWS::RDS::DBClusterSnapshot,AWS::CloudFront::StreamingDistribution"
     }
     capabilities = [

--- a/integration/tests/firehose.tftest.hcl
+++ b/integration/tests/firehose.tftest.hcl
@@ -51,10 +51,11 @@ run "setup" {
 
 run "install" {
   variables {
-    name = run.setup.id
-    app  = "firehose"
+    setup = run.setup
+    app   = "firehose"
     parameters = {
-      BucketARN = "arn:aws:s3:::${run.setup.access_point.bucket}"
+      NameOverride = run.setup.id
+      BucketARN    = "arn:aws:s3:::${run.setup.access_point.bucket}"
     }
     capabilities = [
       "CAPABILITY_IAM",
@@ -83,9 +84,10 @@ run "check_firehose" {
 
 run "set_prefix" {
   variables {
-    name = run.setup.id
-    app  = "firehose"
+    setup = run.setup
+    app   = "firehose"
     parameters = {
+      NameOverride      = run.setup.id
       BucketARN         = "arn:aws:s3:::${run.setup.access_point.bucket}"
       Prefix            = "${run.setup.id}/"
       WriterRoleService = "logs.amazonaws.com"

--- a/integration/tests/forwarder.tftest.hcl
+++ b/integration/tests/forwarder.tftest.hcl
@@ -77,14 +77,15 @@ run "setup" {
 
 run "install_forwarder" {
   variables {
-    name = run.setup.id
-    app  = "forwarder"
+    setup = run.setup
+    app   = "forwarder"
     parameters = {
       DataAccessPointArn   = run.setup.access_point.arn
       DestinationUri       = "s3://${run.setup.access_point.alias}"
-      SourceBucketNames    = "${run.setup.id}-sns,${run.setup.id}-sqs,${run.setup.id}-eventbridge"
+      SourceBucketNames    = "${run.setup.short}-sns,${run.setup.short}-sqs,${run.setup.short}-eventbridge"
       SourceTopicArns      = "arn:aws:sns:${run.setup.region}:${run.setup.account_id}:*"
       ContentTypeOverrides = "${var.override_match}=${var.override_content_type}"
+      NameOverride         = run.setup.id
     }
     capabilities = [
       "CAPABILITY_NAMED_IAM",
@@ -99,7 +100,7 @@ run "setup_subscriptions" {
   }
 
   variables {
-    run_id             = run.setup.id
+    run_id             = run.setup.short
     queue_arn          = run.install_forwarder.stack.outputs["Queue"]
     sources            = ["sqs", "eventbridge", "sns"]
   }

--- a/integration/tests/metricstream.tftest.hcl
+++ b/integration/tests/metricstream.tftest.hcl
@@ -56,10 +56,11 @@ run "setup" {
 
 run "install" {
   variables {
-    name = run.setup.id
-    app  = "metricstream"
+    setup = run.setup
+    app   = "metricstream"
     parameters = {
-      BucketARN = "arn:aws:s3:::${run.setup.access_point.bucket}"
+      BucketARN    = "arn:aws:s3:::${run.setup.access_point.bucket}"
+      NameOverride = run.setup.id
     }
     capabilities = [
       "CAPABILITY_IAM",

--- a/integration/tests/subscriber.tftest.hcl
+++ b/integration/tests/subscriber.tftest.hcl
@@ -73,11 +73,12 @@ run "setup" {
 
 run "install" {
   variables {
-    name = run.setup.id
-    app  = "subscriber"
+    setup = run.setup
+    app   = "subscriber"
     parameters = {
       LogGroupNamePatterns = "*"
       DiscoveryRate        = "24 hours"
+      NameOverride         = run.setup.id
     }
     capabilities = [
       "CAPABILITY_IAM",

--- a/integration/variables.tf
+++ b/integration/variables.tf
@@ -1,6 +1,10 @@
-variable "name" {
-  description = "Stack name"
-  type        = string
+variable "setup" {
+  description = "Setup module"
+  type = object({
+    stack_name = string
+    short      = string
+  })
+
 }
 
 variable "app" {


### PR DESCRIPTION
Typically we rely on Cloudformation to pick resource names for us. In
some cases however we need stable identifiers, for example IAM role
names that must be assumed from our end, or functions for which we need
to create a log group upfront.

In those cases, we can't necessarily rely on the stack name.
Cloudformation names have a maximum length of 128 characters, which far
exceeds the name limits for most resources in AWS. We need to provide an
override for passing a name that abides by the limits of all the
resources present in a given template.

This change ended up being a bit involved because I had to change the
interface of our setup module. We now create three variables on setup:

- a `stack_name` which is 128 characters long
- an `id` which is 64 characters long
- a `short` identifier which is 32 characters long

We then pass in these variables as necessary to exercise the limits of
our templates.