### PR TITLE
feat: add metric stream filtering

### DIFF
--- a/apps/collection/template.yaml
+++ b/apps/collection/template.yaml
@@ -32,6 +32,10 @@ Metadata:
           - LogGroupNamePatterns
           - LogGroupNamePrefixes
       - Label:
+          default: CloudWatch Metrics
+        Parameters:
+          - MetricStreamFilterURI
+      - Label:
           default: Forwarder Options
         Parameters:
           - SourceBucketNames
@@ -67,7 +71,7 @@ Parameters:
       Name of IAM role expected by Filedrop. This role will be created as part
       of this stack, and must therefore be unique within the account.
     Default: ""
-    MaxLength: 52
+    MaxLength: 51
   IncludeResourceTypes:
     Type: CommaDelimitedList
     Description: >-
@@ -94,6 +98,12 @@ Parameters:
       Comma separated list of prefixes. If not empty, the lambda function will
       only apply to log groups that start with a provided string.
     Default: ''
+  MetricStreamFilterURI:
+    Type: String
+    Description: >-
+      S3 URI containing filters for metrics to be collected by CloudWatch
+      Metrics Stream. If empty, no metrics will be collected.
+    Default: 's3://observeinc/cloudwatchmetrics/filters/recommended.yaml'
 
 Conditions:
   EnableConfig: !Not
@@ -108,6 +118,11 @@ Conditions:
   UseStackName: !Equals
     - !Ref NameOverride
     - ""
+  EnableMetricStream: !Not
+    - !Equals
+      - !Ref MetricStreamFilterURI
+      - ""
+
 Resources:
   Topic:
     Type: "AWS::SNS::Topic"
@@ -228,6 +243,22 @@ Resources:
           - UseStackName
           - !Sub "${AWS::StackName}-LogWriter"
           - !Sub "${NameOverride}-LogWriter"
+  MetricStream:
+    Type: AWS::Serverless::Application
+    Condition: EnableMetricStream
+    Properties:
+      Location: ../metricstream/template.yaml
+      NotificationARNs:
+        - !Ref Topic
+      Parameters:
+        BucketARN: !GetAtt Bucket.Arn
+        Prefix: "cloudwatchmetrics/"
+        FilterURI: !Ref MetricStreamFilterURI
+        NameOverride: !If
+          - UseStackName
+          - !Sub "${AWS::StackName}-MetricStream"
+          - !Sub "${NameOverride}-MetricStream"
+
 Outputs:
   Bucket:
     Description: "S3 Bucket Name"

--- a/apps/metricstream/template.yaml
+++ b/apps/metricstream/template.yaml
@@ -22,6 +22,11 @@ Parameters:
     Description: >-
       Optional prefix to write log records to.
     Default: ''
+  FilterURI:
+    Type: String
+    Description: >-
+      A file hosted in S3 containing list of metrics to stream.
+    Default: 's3://observeinc/cloudwatchmetrics/filters/recommended.yaml'
   OutputFormat:
     Type: String
     Description: >-
@@ -163,9 +168,21 @@ Resources:
                 Resource: !GetAtt 'DeliveryStream.Arn'
   MetricStream:
     Type: AWS::CloudWatch::MetricStream
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            # Disable false positive when using Fn::Transform
+            # https://github.com/aws-cloudformation/cfn-lint/issues/2887
+            - E3002
     Properties:
       FirehoseArn: !GetAtt 'DeliveryStream.Arn'
       RoleArn: !GetAtt MetricStreamRole.Arn
+      'Fn::Transform':
+        Name: "AWS::Include"
+        Parameters:
+          Location: !Ref FilterURI
+      # end of processable content for include
       OutputFormat: !Ref OutputFormat
 
 Outputs:

--- a/docs/metricstream.md
+++ b/docs/metricstream.md
@@ -12,6 +12,7 @@ The application is configurable through several parameters that determine how da
 - **NameOverride**: If specified, sets the name of the Firehose Delivery Stream; otherwise, the stack name is used.
 - **BufferingInterval**: The amount of time Firehose buffers incoming data before delivering it (minimum 60 seconds, maximum 900 seconds).
 - **BufferingSize**: The size of the buffer, in MiBs, that Firehose accumulates before delivering data (minimum 1 MiB, maximum 64 MiBs).
+- **MetricStreamFilterURI**: An S3 URI containing a filter for collected metrics.
 
 ## Resources Created
 
@@ -22,6 +23,23 @@ The CloudWatch Metrics Stream application provisions the following AWS resources
 - **CloudWatch Log Stream**: A specific log stream for storing Firehose delivery logs.
 - **Kinesis Firehose Delivery Stream**: The core component that manages the delivery of data to the S3 bucket.
 - **CloudWatch Metrics Stream**: the component responsible for writing metrics to Kinesis Firehose.
+
+
+## Filtering metrics
+
+This module requires a URI to a pubicly readable S3 object containing a YAML or JSON definition
+for what metrics to collect. Observe hosts some boilerplate filters you can use:
+
+- `s3://observeinc/cloudwatchmetrics/filters/full.yaml` collects all metrics.
+- `s3://observeinc/cloudwatchmetrics/filters/recommended.yaml` collects a set of KPIs for each metric namespace.
+
+You can use `curl` to inspect the content of these files, e.g.:
+
+```
+curl https://observeinc.s3.us-west-2.amazonaws.com/cloudwatchmetrics/filters/recommended.yaml
+```
+
+You can host your own definition, so long as it conforms with the schema for [AWS::CloudWatch::MetricStream](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudwatch-metricstream.html). 
 
 ## Deployment
 

--- a/integration/tests/collection.tftest.hcl
+++ b/integration/tests/collection.tftest.hcl
@@ -8,8 +8,13 @@ variables {
         "Action": [
           "cloudformation:CreateChangeSet",
           "cloudformation:CreateStack",
+          "cloudformation:DeleteChangeSet",
           "cloudformation:DeleteStack",
           "cloudformation:DescribeStacks",
+          "cloudwatch:DeleteMetricStream",
+          "cloudwatch:GetMetricStream",
+          "cloudwatch:PutMetricStream",
+          "cloudwatch:TagResource",
           "config:DeleteConfigurationRecorder",
           "config:DeleteDeliveryChannel",
           "config:DescribeConfigurationRecorderStatus",
@@ -42,6 +47,7 @@ variables {
           "iam:ListRolePolicies",
           "iam:PassRole",
           "iam:PutRolePolicy",
+          "iam:TagRole",
           "iam:UpdateRole",
           "kms:CreateGrant",
           "kms:Decrypt",
@@ -107,6 +113,15 @@ variables {
           "sqs:UntagQueue"
         ],
         "Resource": "*"
+      },
+      {
+        "Effect": "Allow",
+        "Action": [
+          "s3:GetObject"
+        ],
+        "Resource": [
+          "arn:aws:s3:::observeinc/cloudwatchmetrics/filters/*"
+        ]
       }
     ]
   }
@@ -119,7 +134,7 @@ run "setup" {
     version = "2.6.0"
   }
   variables {
-    id_length = 52
+    id_length = 51
   }
 }
 

--- a/integration/tests/metricstream.tftest.hcl
+++ b/integration/tests/metricstream.tftest.hcl
@@ -6,7 +6,9 @@ variables {
       {
         "Effect": "Allow",
         "Action": [
+          "cloudformation:CreateChangeSet",
           "cloudformation:CreateStack",
+          "cloudformation:DeleteChangeSet",
           "cloudformation:DeleteStack",
           "cloudformation:DescribeStacks",
           "cloudwatch:DeleteMetricStream",
@@ -29,6 +31,7 @@ variables {
           "iam:ListRolePolicies",
           "iam:PassRole",
           "iam:PutRolePolicy",
+          "iam:TagRole",
           "iam:UpdateRole",
           "logs:CreateLogGroup",
           "logs:CreateLogStream",
@@ -42,6 +45,15 @@ variables {
           "logs:UntagResource"
         ],
         "Resource": "*"
+      },
+      {
+        "Effect": "Allow",
+        "Action": [
+          "s3:GetObject"
+        ],
+        "Resource": [
+          "arn:aws:s3:::observeinc/cloudwatchmetrics/filters/*"
+        ]
       }
     ]
   }
@@ -65,6 +77,23 @@ run "install" {
     }
     capabilities = [
       "CAPABILITY_IAM",
+      "CAPABILITY_AUTO_EXPAND",
+    ]
+  }
+}
+
+run "update" {
+  variables {
+    setup = run.setup
+    app   = "metricstream"
+    parameters = {
+      BucketARN    = "arn:aws:s3:::${run.setup.access_point.bucket}"
+      NameOverride = run.setup.id
+      OutputFormat = "opentelemetry1.0"
+    }
+    capabilities = [
+      "CAPABILITY_IAM",
+      "CAPABILITY_AUTO_EXPAND",
     ]
   }
 }


### PR DESCRIPTION
This commit adds the ability to filter metrics collected by CloudWatch Metrics Stream. This feature was sorely missing in our previous stacks, leading to excessive collection costs.

The difficulty in filtering metrics in CloudFormation derives from its complete lack of expressiveness. There's no way to take a user input in the supported types and fill out the complex structure that defines include and exclude filters.

The solution is to instead host a template snippet in S3, and allow customers to point at their own derived versions. This allows us to maintain a trimmed down set of metrics without affecting a customer's ability to fine tune the set for their own needs.