### PR TITLE
refactor: extract mux

### DIFF
--- a/handler/forwarder/handler.go
+++ b/handler/forwarder/handler.go
@@ -17,8 +17,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/go-logr/logr"
-
-	"github.com/observeinc/aws-sam-apps/handler"
 )
 
 var errNoLambdaContext = fmt.Errorf("no lambda context found")
@@ -29,7 +27,7 @@ type S3Client interface {
 }
 
 type Handler struct {
-	handler.Mux
+	Logger              logr.Logger
 	MaxFileSize         int64
 	DestinationURI      *url.URL
 	LogPrefix           string
@@ -166,6 +164,7 @@ func New(cfg *Config) (h *Handler, err error) {
 	m, _ := NewContentTypeOverrides(cfg.ContentTypeOverrides, defaultDelimiter)
 
 	h = &Handler{
+		Logger:              logr.Discard(),
 		DestinationURI:      u,
 		LogPrefix:           cfg.LogPrefix,
 		S3Client:            cfg.S3Client,
@@ -175,11 +174,7 @@ func New(cfg *Config) (h *Handler, err error) {
 	}
 
 	if cfg.Logger != nil {
-		h.Mux.Logger = *cfg.Logger
-	}
-
-	if err := h.Mux.Register(h.Handle); err != nil {
-		return nil, fmt.Errorf("failed to register functions: %w", err)
+		h.Logger = *cfg.Logger
 	}
 
 	return h, nil

--- a/handler/subscriber/handler.go
+++ b/handler/subscriber/handler.go
@@ -12,8 +12,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
 	"github.com/go-logr/logr"
-
-	"github.com/observeinc/aws-sam-apps/handler"
 )
 
 var (
@@ -33,11 +31,10 @@ type Queue interface {
 }
 
 type Handler struct {
-	handler.Mux
-
 	Queue      Queue
 	Client     CloudWatchLogsClient
 	NumWorkers int
+	Logger     logr.Logger
 
 	subscriptionFilter types.SubscriptionFilter
 	logGroupNameFilter FilterFunc
@@ -87,6 +84,7 @@ func New(cfg *Config) (*Handler, error) {
 	}
 
 	h := &Handler{
+		Logger:     logr.Discard(),
 		Client:     cfg.CloudWatchLogsClient,
 		Queue:      cfg.Queue,
 		NumWorkers: cfg.NumWorkers,
@@ -105,10 +103,6 @@ func New(cfg *Config) (*Handler, error) {
 
 	if cfg.Logger != nil {
 		h.Logger = *cfg.Logger
-	}
-
-	if err := h.Mux.Register(h.HandleRequest, h.HandleSQS); err != nil {
-		return nil, fmt.Errorf("failed to register handler: %w", err)
 	}
 
 	return h, nil


### PR DESCRIPTION
Rather than embedding the mux in each handler, separate the business logic of each handler from the entrypoint of the Lambda. This makes instrumentation simpler, since we can wrap handlers and still mount them for a given entrypoint.