### PR TITLE
feat: add preset for cloudwatch logs

### DIFF
--- a/apps/collection/template.yaml
+++ b/apps/collection/template.yaml
@@ -197,11 +197,8 @@ Resources:
                   - !Join [",", !Ref SourceBucketNames]
         SourceTopicArns: !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:*"
         ContentTypeOverrides: !Join
-            - ","
-            - - !Sub "${Bucket}/cloudwatchlogs/=application/x-aws-cloudwatchlogs"
-              - !Join
-                - ","
-                - !Ref ContentTypeOverrides
+          - ","
+          - !Ref ContentTypeOverrides
         NameOverride: !If
           - UseStackName
           - !Ref AWS::StackName

--- a/handler/forwarder/override/presets/aws/v1.yaml
+++ b/handler/forwarder/override/presets/aws/v1.yaml
@@ -1,3 +1,10 @@
+- id: cloudwatchLogs
+  match:
+    source: '/cloudwatchlogs/\d{4}/\d{2}/\d{2}/\d{2}'
+  override:
+    content-type: 'application/x-aws-cloudwatchlogs'
+    content-encoding: 'gzip'
+
 - id: configSnapshot
   match:
     source: '\d{12}_Config_[a-z\d-]+_ConfigSnapshot_\d{8}T\d{6}Z_[a-f\d-]+\.json\.gz$'

--- a/handler/forwarder/override/presets_test.go
+++ b/handler/forwarder/override/presets_test.go
@@ -1,0 +1,73 @@
+package override_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/go-logr/logr"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
+	"github.com/observeinc/aws-sam-apps/handler/forwarder/override"
+)
+
+func TestPresets(t *testing.T) {
+	t.Parallel()
+
+	testcases := []struct {
+		Presets []string
+		Expect  []VerifyApply
+	}{
+		{
+			Presets: []string{"aws/v1"},
+			Expect: []VerifyApply{
+				{
+					Input: &s3.CopyObjectInput{
+						CopySource:      aws.String("test-bucket/AWSLogs/723346149663/Config/us-west-2/2023/10/10/OversizedChangeNotification/AWS::SSM::ManagedInstanceInventory/i-0c08bc770c167d93c/723346149663_Config_us-west-2_ChangeNotification_AWS::SSM::ManagedInstanceInventory_i-0c08bc770c167d93c_20231010T203453Z_1696970093120.json.gz"),
+						ContentEncoding: aws.String("gzip"),
+					},
+					Expect: &s3.CopyObjectInput{
+						CopySource:        aws.String("test-bucket/AWSLogs/723346149663/Config/us-west-2/2023/10/10/OversizedChangeNotification/AWS::SSM::ManagedInstanceInventory/i-0c08bc770c167d93c/723346149663_Config_us-west-2_ChangeNotification_AWS::SSM::ManagedInstanceInventory_i-0c08bc770c167d93c_20231010T203453Z_1696970093120.json.gz"),
+						ContentType:       aws.String("application/x-aws-change"),
+						ContentEncoding:   aws.String("gzip"),
+						MetadataDirective: types.MetadataDirectiveReplace,
+					},
+				},
+				{
+					Input: &s3.CopyObjectInput{
+						CopySource: aws.String("test-bucket/cloudwatchlogs/2024/02/27/22/quality-bird-logwriter-1-2024-02-27-22-16-04-7828720f-2bd1-4b15-9f4c-b33f06f4a9c0"),
+					},
+					Expect: &s3.CopyObjectInput{
+						CopySource:        aws.String("test-bucket/cloudwatchlogs/2024/02/27/22/quality-bird-logwriter-1-2024-02-27-22-16-04-7828720f-2bd1-4b15-9f4c-b33f06f4a9c0"),
+						ContentType:       aws.String("application/x-aws-cloudwatchlogs"),
+						ContentEncoding:   aws.String("gzip"),
+						MetadataDirective: types.MetadataDirectiveReplace,
+					},
+				},
+			},
+		},
+	}
+
+	for i, tc := range testcases {
+		tc := tc
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			t.Parallel()
+			ss, err := override.LoadPresets(logr.Discard(), tc.Presets...)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			set := override.Sets(ss)
+			for i, pair := range tc.Expect {
+				set.Apply(context.Background(), pair.Input)
+				if diff := cmp.Diff(pair.Input, pair.Expect, cmpopts.IgnoreUnexported(s3.CopyObjectInput{})); diff != "" {
+					t.Fatalf("failed to process %d: %s", i, diff)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add a content type and encoding override for CloudWatch Logs. There is no fixed filename format we can rely on, so we just adjust the filename pattern to what our collection produces, which by default dumps Firehose records under a `cloudwatchlogs/` prefix.