### PR TITLE
fix: override cloudwatch metrics, adjust prefixes

### DIFF
--- a/apps/collection/template.yaml
+++ b/apps/collection/template.yaml
@@ -232,7 +232,6 @@ Resources:
         - !Ref Topic
       Parameters:
         BucketARN: !GetAtt Bucket.Arn
-        Prefix: "cloudwatchlogs/"
         LogGroupNamePrefixes: !Join [",", !Ref LogGroupNamePrefixes]
         LogGroupNamePatterns: !Join [",", !Ref LogGroupNamePatterns]
         FilterName: 'observe-logs-subscription'
@@ -250,7 +249,6 @@ Resources:
         - !Ref Topic
       Parameters:
         BucketARN: !GetAtt Bucket.Arn
-        Prefix: "cloudwatchmetrics/"
         FilterURI: !Ref MetricStreamFilterURI
         NameOverride: !If
           - UseStackName

--- a/apps/logwriter/template.yaml
+++ b/apps/logwriter/template.yaml
@@ -183,8 +183,8 @@ Resources:
       S3DestinationConfiguration:
         BucketARN: !Ref BucketARN
         RoleARN: !GetAtt FirehoseRole.Arn
-        Prefix: !Ref Prefix
-        ErrorOutputPrefix: !Ref Prefix
+        Prefix: !Sub '${Prefix}cloudwatchlogs/'
+        ErrorOutputPrefix: !Sub '${Prefix}cloudwatchlogs/errors'
         BufferingHints:
           IntervalInSeconds: !Ref BufferingInterval
           SizeInMBs: !Ref BufferingSize

--- a/apps/metricstream/template.yaml
+++ b/apps/metricstream/template.yaml
@@ -1,10 +1,10 @@
 ---
 AWSTemplateFormatVersion: '2010-09-09'
-Description: 'Stream Firehose Records to S3.'
+Description: 'Stream CloudWatch Metrics to S3.'
 Metadata:
   AWS::ServerlessRepo::Application:
     Name: observe-metric-stream
-    Description: Stream CloudWatch Metric Stream to S3.
+    Description: Stream CloudWatch Metrics to S3.
     Author: Observe Inc
     SpdxLicenseId: Apache-2.0
     ReadmeUrl: README.md
@@ -20,7 +20,7 @@ Parameters:
   Prefix:
     Type: String
     Description: >-
-      Optional prefix to write log records to.
+      Optional prefix to write metrics to.
     Default: ''
   FilterURI:
     Type: String
@@ -131,8 +131,8 @@ Resources:
       S3DestinationConfiguration:
         BucketARN: !Ref BucketARN
         RoleARN: !GetAtt DeliveryStreamRole.Arn
-        Prefix: !Ref Prefix
-        ErrorOutputPrefix: !Ref Prefix
+        Prefix: !Sub '${Prefix}cloudwatchmetrics/${OutputFormat}/'
+        ErrorOutputPrefix: !Sub '${Prefix}cloudwatchmetrics/errors/'
         BufferingHints:
           IntervalInSeconds: !Ref BufferingInterval
           SizeInMBs: !Ref BufferingSize

--- a/handler/forwarder/override/presets/aws/v1.yaml
+++ b/handler/forwarder/override/presets/aws/v1.yaml
@@ -5,6 +5,12 @@
     content-type: 'application/x-aws-cloudwatchlogs'
     content-encoding: 'gzip'
 
+- id: cloudwatchMetrics
+  match:
+    source: '/cloudwatchmetrics/json/\d{4}/\d{2}/\d{2}/\d{2}'
+  override:
+    content-type: 'application/x-aws-cloudwatchmetrics'
+
 - id: configSnapshot
   match:
     source: '\d{12}_Config_[a-z\d-]+_ConfigSnapshot_\d{8}T\d{6}Z_[a-f\d-]+\.json\.gz$'


### PR DESCRIPTION
This commit adds a preset for identifying cloudwatch metrics stream data, which will be submitted with content type
`application/x-aws-cloudwatchmetrics`.

In the process, I've how object prefixes get set. Previously we were overriding prefixes in the collection module. This is awkward given we now have preset rules that look for specific paths in the object key. Installing the "logwriter" app as a standalone would not work as expected with a standalone "forwarder" app.

We now "hardcode" the prefixes we require for content type inference. This ensures users have no way of fudging configuration when using our apps.