### PR TITLE
fix: set logger context in mux

### DIFF
--- a/cmd/forwarder/main.go
+++ b/cmd/forwarder/main.go
@@ -99,5 +99,5 @@ func realInit() error {
 }
 
 func main() {
-	lambda.Start(handler.Handle)
+	lambda.Start(handler)
 }

--- a/cmd/subscriber/main.go
+++ b/cmd/subscriber/main.go
@@ -54,7 +54,6 @@ func realInit() error {
 	logger = logging.New(&logging.Config{
 		Verbosity: env.Verbosity,
 	})
-	ctx = logr.NewContext(ctx, logger)
 	logger.V(4).Info("initialized", "config", env)
 
 	// If user has not provided an override, we must reapply these environment

--- a/handler/mux.go
+++ b/handler/mux.go
@@ -87,8 +87,8 @@ func (m *Mux) Invoke(ctx context.Context, payload []byte) (response []byte, err 
 	logger := m.Logger
 	if lctx, ok := lambdacontext.FromContext(ctx); ok {
 		logger = m.Logger.WithValues("requestId", lctx.AwsRequestID)
-		ctx = logr.NewContext(ctx, logger)
 	}
+	ctx = logr.NewContext(ctx, logger)
 
 	logger.V(3).Info("handling request")
 	defer func() {


### PR DESCRIPTION
The logging context should be handled by the mux layer, since that covers both our forwarder and subscriber lambda. Previously we were only setting the logger if we encountered the lambda context.