### PR TITLE
fix: add region to cwlogs and metrics path

### DIFF
--- a/apps/logwriter/template.yaml
+++ b/apps/logwriter/template.yaml
@@ -188,8 +188,8 @@ Resources:
       S3DestinationConfiguration:
         BucketARN: !Ref BucketARN
         RoleARN: !GetAtt FirehoseRole.Arn
-        Prefix: !Sub '${Prefix}cloudwatchlogs/'
-        ErrorOutputPrefix: !Sub '${Prefix}cloudwatchlogs/errors'
+        Prefix: !Sub '${Prefix}AWSLogs/${AWS::AccountId}/cloudwatchlogs/${AWS::Region}/'
+        ErrorOutputPrefix: !Sub '${Prefix}AWSLogs/${AWS::AccountId}/cloudwatchlogs/${AWS::Region}/errors'
         BufferingHints:
           IntervalInSeconds: !Ref BufferingInterval
           SizeInMBs: !Ref BufferingSize

--- a/apps/metricstream/template.yaml
+++ b/apps/metricstream/template.yaml
@@ -131,8 +131,8 @@ Resources:
       S3DestinationConfiguration:
         BucketARN: !Ref BucketARN
         RoleARN: !GetAtt DeliveryStreamRole.Arn
-        Prefix: !Sub '${Prefix}cloudwatchmetrics/${OutputFormat}/'
-        ErrorOutputPrefix: !Sub '${Prefix}cloudwatchmetrics/errors/'
+        Prefix: !Sub '${Prefix}AWSLogs/${AWS::AccountId}/cloudwatchmetrics/${AWS::Region}/${OutputFormat}/'
+        ErrorOutputPrefix: !Sub '${Prefix}AWSLogs/${AWS::AccountId}/cloudwatchmetrics/${AWS::Region}/errors/'
         BufferingHints:
           IntervalInSeconds: !Ref BufferingInterval
           SizeInMBs: !Ref BufferingSize

--- a/handler/forwarder/override/presets/aws/v1.yaml
+++ b/handler/forwarder/override/presets/aws/v1.yaml
@@ -1,13 +1,13 @@
 - id: cloudwatchLogs
   match:
-    source: '/cloudwatchlogs/\d{4}/\d{2}/\d{2}/\d{2}'
+    source: '/cloudwatchlogs/[a-z\d-]+/\d{4}/\d{2}/\d{2}/\d{2}'
   override:
     content-type: 'application/x-aws-cloudwatchlogs'
     content-encoding: 'gzip'
 
 - id: cloudwatchMetrics
   match:
-    source: '/cloudwatchmetrics/json/\d{4}/\d{2}/\d{2}/\d{2}'
+    source: '/cloudwatchmetrics/[a-z\d-]+/json/\d{4}/\d{2}/\d{2}/\d{2}'
   override:
     content-type: 'application/x-aws-cloudwatchmetrics'
 

--- a/handler/forwarder/override/presets_test.go
+++ b/handler/forwarder/override/presets_test.go
@@ -39,10 +39,10 @@ func TestPresets(t *testing.T) {
 				},
 				{
 					Input: &s3.CopyObjectInput{
-						CopySource: aws.String("test-bucket/cloudwatchlogs/2024/02/27/22/quality-bird-logwriter-1-2024-02-27-22-16-04-7828720f-2bd1-4b15-9f4c-b33f06f4a9c0"),
+						CopySource: aws.String("test-bucket/cloudwatchlogs/us-west-2/2024/02/27/22/quality-bird-logwriter-1-2024-02-27-22-16-04-7828720f-2bd1-4b15-9f4c-b33f06f4a9c0"),
 					},
 					Expect: &s3.CopyObjectInput{
-						CopySource:        aws.String("test-bucket/cloudwatchlogs/2024/02/27/22/quality-bird-logwriter-1-2024-02-27-22-16-04-7828720f-2bd1-4b15-9f4c-b33f06f4a9c0"),
+						CopySource:        aws.String("test-bucket/cloudwatchlogs/us-west-2/2024/02/27/22/quality-bird-logwriter-1-2024-02-27-22-16-04-7828720f-2bd1-4b15-9f4c-b33f06f4a9c0"),
 						ContentType:       aws.String("application/x-aws-cloudwatchlogs"),
 						ContentEncoding:   aws.String("gzip"),
 						MetadataDirective: types.MetadataDirectiveReplace,


### PR DESCRIPTION
CloudWatch data does not necessarily contain the region the data was collected from. We need to record the region in the object key. Given firehose does not allow specifying a filename for records, we must either:

- ensure region is part of the firehose name, which is part of the S3 object key
- ensure region is part of the object prefix

This commit adopts a pre-existing convention whereby AWS services dump their data under `AWSLogs/{accountId}/{service}/{region}`.