### PR TITLE
fix(forwarder): remove log prefix

### DIFF
--- a/cmd/forwarder/main.go
+++ b/cmd/forwarder/main.go
@@ -17,7 +17,6 @@ import (
 
 var env struct {
 	DestinationURI       string           `env:"DESTINATION_URI,required"`
-	LogPrefix            string           `env:"LOG_PREFIX,default=forwarder/"`
 	Verbosity            int              `env:"VERBOSITY,default=1"`
 	MaxFileSize          int64            `env:"MAX_FILE_SIZE"`
 	ContentTypeOverrides []*override.Rule `env:"CONTENT_TYPE_OVERRIDES"`
@@ -72,7 +71,6 @@ func realInit() error {
 
 	handler, err = forwarder.New(&forwarder.Config{
 		DestinationURI:    env.DestinationURI,
-		LogPrefix:         env.LogPrefix,
 		MaxFileSize:       env.MaxFileSize,
 		S3Client:          s3client,
 		Logger:            &logger,

--- a/handler/forwarder/config.go
+++ b/handler/forwarder/config.go
@@ -16,7 +16,6 @@ var (
 
 type Config struct {
 	DestinationURI    string // S3 URI to write messages and copy files to
-	LogPrefix         string // prefix used when writing SQS messages to S3
 	MaxFileSize       int64  // maximum file size in bytes for the files to be processed
 	SourceBucketNames []string
 	Override          Override

--- a/handler/forwarder/handler.go
+++ b/handler/forwarder/handler.go
@@ -35,7 +35,6 @@ type Handler struct {
 	handler.Mux
 	MaxFileSize       int64
 	DestinationURI    *url.URL
-	LogPrefix         string
 	S3Client          S3Client
 	Override          Override
 	SourceBucketNames []string
@@ -75,7 +74,7 @@ func (h *Handler) WriteSQS(ctx context.Context, r io.Reader) error {
 		return errNoLambdaContext
 	}
 
-	key := fmt.Sprintf("%s/%s%s/%s", strings.Trim(h.DestinationURI.Path, "/"), h.LogPrefix, lctx.InvokedFunctionArn, lctx.AwsRequestID)
+	key := fmt.Sprintf("%s/%s/%s", strings.Trim(h.DestinationURI.Path, "/"), lctx.InvokedFunctionArn, lctx.AwsRequestID)
 
 	_, err := h.S3Client.PutObject(ctx, &s3.PutObjectInput{
 		Bucket:      aws.String(h.DestinationURI.Host),
@@ -169,7 +168,6 @@ func New(cfg *Config) (h *Handler, err error) {
 
 	h = &Handler{
 		DestinationURI:    u,
-		LogPrefix:         cfg.LogPrefix,
 		S3Client:          cfg.S3Client,
 		MaxFileSize:       cfg.MaxFileSize,
 		Override:          cfg.Override,

--- a/handler/forwarder/handler_test.go
+++ b/handler/forwarder/handler_test.go
@@ -284,7 +284,6 @@ func TestRecorder(t *testing.T) {
 
 	testcases := []struct {
 		LambdaContext  *lambdacontext.LambdaContext
-		LogPrefix      string
 		DestinationURI string
 		Expect         *s3.PutObjectInput
 	}{
@@ -293,11 +292,10 @@ func TestRecorder(t *testing.T) {
 				InvokedFunctionArn: "arn:aws:lambda:us-east-1:123456789012:function:test",
 				AwsRequestID:       "c8ee04d5-5925-541a-b113-5942a0fc5985",
 			},
-			LogPrefix:      "test/",
 			DestinationURI: "s3://my-bucket/path/to",
 			Expect: &s3.PutObjectInput{
 				Bucket:      aws.String("my-bucket"),
-				Key:         aws.String("path/to/test/arn:aws:lambda:us-east-1:123456789012:function:test/c8ee04d5-5925-541a-b113-5942a0fc5985"),
+				Key:         aws.String("path/to/arn:aws:lambda:us-east-1:123456789012:function:test/c8ee04d5-5925-541a-b113-5942a0fc5985"),
 				ContentType: aws.String("application/x-ndjson"),
 			},
 		},
@@ -312,7 +310,6 @@ func TestRecorder(t *testing.T) {
 
 			h, err := forwarder.New(&forwarder.Config{
 				DestinationURI: tc.DestinationURI,
-				LogPrefix:      tc.LogPrefix,
 				S3Client: &handlertest.S3Client{
 					PutObjectFunc: func(_ context.Context, i *s3.PutObjectInput, _ ...func(*s3.Options)) (*s3.PutObjectOutput, error) {
 						got = i


### PR DESCRIPTION
This isn't necessary, since user could provide a prefix in the destination URI.