### PR TITLE
fix: export defaults to environment variables

### DIFF
--- a/handler/env.go
+++ b/handler/env.go
@@ -1,0 +1,29 @@
+package handler
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/sethvargo/go-envconfig"
+)
+
+// exportEnvVar ensures we export resolved values back into the environment
+// This is useful for cases where we set a default in our env struct, and need
+// the value to be propagated to other processes.
+func exportEnvVar(_ context.Context, _, resolvedKey, _, resolvedValue string) (newValue string, stop bool, err error) {
+	os.Setenv(resolvedKey, resolvedValue)
+	return resolvedValue, false, nil
+}
+
+// ProcessEnv populates struct from environment variables.
+func ProcessEnv(ctx context.Context, v any) error {
+	err := envconfig.ProcessWith(ctx, &envconfig.Config{
+		Target:   v,
+		Mutators: []envconfig.Mutator{envconfig.MutatorFunc(exportEnvVar)},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to load environment variables: %w", err)
+	}
+	return nil
+}

--- a/handler/env_test.go
+++ b/handler/env_test.go
@@ -1,0 +1,30 @@
+package handler_test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/observeinc/aws-sam-apps/handler"
+)
+
+func TestEnv(t *testing.T) {
+	env := struct {
+		Embedded struct {
+			Test         string `env:"TEST,default=hello"`
+			ListOfValues string `env:"LISTOFVALUES"`
+		} `env:", prefix=T_"`
+	}{}
+
+	if v := os.Getenv("T_TEST"); v != "" {
+		t.Fatal("found unexpected environment variable")
+	}
+
+	if err := handler.ProcessEnv(context.Background(), &env); err != nil {
+		t.Fatal(err)
+	}
+
+	if v := os.Getenv("T_TEST"); v != "hello" {
+		t.Fatal("default was not exported back to environment")
+	}
+}


### PR DESCRIPTION
Setting a default in our env struct currently only affects the value being read into the struct. It is generally useful to have that value exporting back to the environment, in the case where other libraries source their configuration from the environment directly.

An existing usecase is where we modify the default for `AWS_MAX_ATTEMPTS`. The AWS SDK reads this environment variable directly when configuring the client.