### PR TITLE
feat(forwarder): add OTEL tracing

### DIFF
--- a/apps/forwarder/template.yaml
+++ b/apps/forwarder/template.yaml
@@ -26,6 +26,13 @@ Metadata:
         Parameters:
           - SourceBucketNames
           - SourceTopicArns
+      - Label:
+          default: Miscellaneous
+        Parameters:
+          - MaxFileSize
+          - ContentTypeOverrides
+          - SourceKMSKeyArns
+          - DebugEndpoint
 
 Globals:
   Function:
@@ -86,6 +93,12 @@ Parameters:
       A list of KMS Key ARNs the forwarder is allowed to use to decrypt objects in S3.
     Default: ''
     AllowedPattern: "^(arn:.*)?$"
+  DebugEndpoint:
+    Type: String
+    Description: >-
+      Endpoint to send additional debug telemetry to.
+    Default: ''
+    AllowedPattern: "^(http(s)?:\/\/.*)?$"
 Conditions:
   IsMaxFileSizeEmpty: !Equals [ !Ref MaxFileSize, '' ]
   DisableSourceS3: !Equals
@@ -100,6 +113,9 @@ Conditions:
     - ''
   UseStackName: !Equals
     - !Ref NameOverride
+    - ''
+  DisableOTEL: !Equals
+    - !Ref DebugEndpoint
     - ''
 
 Resources:
@@ -323,6 +339,8 @@ Resources:
           SOURCE_BUCKET_NAMES: !Join
             - ','
             - !Ref SourceBucketNames
+          OTEL_EXPORTER_OTLP_ENDPOINT: !Ref DebugEndpoint
+          OTEL_TRACES_EXPORTER: !If [ DisableOTEL, "none", "otlp" ]
 Outputs:
   Function:
     Description: "Lambda Function ARN"

--- a/handler/forwarder/config.go
+++ b/handler/forwarder/config.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"net/url"
 	"time"
-
-	"github.com/go-logr/logr"
 )
 
 var (
@@ -21,7 +19,6 @@ type Config struct {
 	SourceBucketNames []string
 	Override          Override
 	S3Client          S3Client
-	Logger            *logr.Logger
 	GetTime           func() *time.Time
 }
 

--- a/handler/forwarder/handler.go
+++ b/handler/forwarder/handler.go
@@ -192,13 +192,5 @@ func New(cfg *Config) (h *Handler, err error) {
 		Now:               time.Now,
 	}
 
-	if cfg.Logger != nil {
-		h.Mux.Logger = *cfg.Logger
-	}
-
-	if err := h.Mux.Register(h.Handle); err != nil {
-		return nil, fmt.Errorf("failed to register functions: %w", err)
-	}
-
 	return h, nil
 }

--- a/handler/forwarder/handler_test.go
+++ b/handler/forwarder/handler_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/aws/aws-lambda-go/lambdacontext"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
-	"github.com/go-logr/logr/testr"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 
@@ -251,11 +250,6 @@ func TestHandler(t *testing.T) {
 			var request events.SQSEvent
 			if err := json.Unmarshal(data, &request); err != nil {
 				t.Fatal(err)
-			}
-
-			if tc.Config.Logger != nil {
-				logger := testr.New(t)
-				tc.Config.Logger = &logger
 			}
 
 			h, err := forwarder.New(&tc.Config)

--- a/integration/tests/forwarder.tftest.hcl
+++ b/integration/tests/forwarder.tftest.hcl
@@ -59,7 +59,8 @@ variables {
           "sqs:GetQueueAttributes",
           "sqs:GetQueueUrl",
           "sqs:PurgeQueue",
-          "sqs:SetQueueAttributes"
+          "sqs:SetQueueAttributes",
+          "sqs:TagQueue"
         ],
         "Resource": "*"
       }
@@ -243,10 +244,10 @@ run "check_kms" {
   variables {
     command = "./scripts/check_object_diff"
     env_vars = {
-      SOURCE                 = run.sources.buckets["kms"].id
-      DESTINATION            = run.target_bucket.id
+      SOURCE      = run.sources.buckets["kms"].id
+      DESTINATION = run.target_bucket.id
       # Object ETag will no longer match because object hash changes after decryption
-      JQ_PROCESS_SOURCE      = "del(.ETag)"
+      JQ_PROCESS_SOURCE = "del(.ETag)"
       # Reset the expected source encryption settings when comparing objects
       JQ_PROCESS_DESTINATION = "del(.ETag) | .ServerSideEncryption = \"aws:kms\" | .SSEKMSKeyId = \"${run.sources.buckets["kms"].kms_key.arn}\""
     }

--- a/tracing/aws.go
+++ b/tracing/aws.go
@@ -1,0 +1,20 @@
+package tracing
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func AWSLoadDefaultConfig(ctx context.Context, tracerProvider trace.TracerProvider) (aws.Config, error) {
+	awsCfg, err := config.LoadDefaultConfig(ctx)
+	if err != nil {
+		return awsCfg, fmt.Errorf("failed to load AWS configuration: %w", err)
+	}
+	otelaws.AppendMiddlewares(&awsCfg.APIOptions, otelaws.WithTracerProvider(tracerProvider))
+	return awsCfg, nil
+}

--- a/tracing/mux.go
+++ b/tracing/mux.go
@@ -1,0 +1,30 @@
+package tracing
+
+import (
+	"context"
+
+	"github.com/aws/aws-lambda-go/lambda"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type LambdaHandler struct {
+	Tracer trace.Tracer
+	lambda.Handler
+}
+
+func (h *LambdaHandler) Invoke(ctx context.Context, payload []byte) (response []byte, err error) {
+	cctx, span := h.Tracer.Start(ctx, "Invoke", trace.WithAttributes(
+		attribute.String("payload", string(payload)),
+	))
+	defer func() {
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+		}
+		span.End()
+	}()
+	response, err = h.Handler.Invoke(cctx, payload)
+	return
+}

--- a/tracing/tracing.go
+++ b/tracing/tracing.go
@@ -1,0 +1,64 @@
+package tracing
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+
+	"go.opentelemetry.io/contrib/detectors/aws/lambda"
+	"go.opentelemetry.io/contrib/exporters/autoexport"
+	"go.opentelemetry.io/otel/sdk/resource"
+	"go.opentelemetry.io/otel/sdk/trace"
+)
+
+// The OTEL SDK does not handle basic auth in OTEL_EXPORTER_OTLP_ENDPOINT
+// Extract username and password and set as OTLP Headers.
+func handleOTLPEndpointAuth() error {
+	endpoint := os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
+	if endpoint == "" {
+		return nil
+	}
+
+	if u, err := url.Parse(endpoint); err != nil {
+		return fmt.Errorf("failed to parse OTEL_EXPORTER_OTLP_ENDPOINT: %w", err)
+	} else if userinfo := u.User; userinfo != nil {
+		authHeader := "Bearer " + userinfo.String()
+
+		headers := os.Getenv("OTEL_EXPORTER_OTLP_HEADERS")
+		if headers != "" {
+			headers += ","
+		}
+		headers += "Authorization=" + authHeader
+
+		// remove auth from URL
+		u.User = nil
+		os.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", u.String())
+		os.Setenv("OTEL_EXPORTER_OTLP_HEADERS", headers)
+	}
+	return nil
+}
+
+func NewTracerProvider(ctx context.Context) (*trace.TracerProvider, error) {
+	if err := handleOTLPEndpointAuth(); err != nil {
+		return nil, fmt.Errorf("failed to handle OTLP endpoint auth: %w", err)
+	}
+
+	res, err := resource.New(ctx,
+		resource.WithDetectors(lambda.NewResourceDetector()),
+		resource.WithFromEnv(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create resource: %w", err)
+	}
+
+	exporter, err := autoexport.NewSpanExporter(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create span exporter: %w", err)
+	}
+
+	return trace.NewTracerProvider(
+		trace.WithBatcher(exporter),
+		trace.WithResource(res),
+	), nil
+}


### PR DESCRIPTION
This commit adds OTEL tracing capabilities to the Forwarder lambda. I've so far left the subscriber lambda untouched, but this is the first step of moving the OTEL bits into a shared package.

The proposed code simplifies setup somewhat:

- we set the `OTEL_TRACES_EXPORTER` env var to `none` by default. This simplifies some of the intialization code we had prior.
- we instantiate a Tracer at `cmd`, and pass it into an instrumented Handler
- we explicitly pass `TracerProvider` where necessary rather than relying on global variables.