### PR TITLE
feat(forwarder): set version on build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ terraform.tfvars
 tfplan
 
 .terraform.lock.hcl
+.make.env

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ AWS_REGION ?= $(shell aws configure get region)
 SAM_BUILD_DIR ?= .aws-sam/build
 SAM_CONFIG_FILE ?= $(shell pwd)/samconfig.yaml
 SAM_CONFIG_ENV ?= default
+BUILD_MAKEFILE_ENV_VARS = .make.env
 
 DEBUG ?= 0
 
@@ -77,6 +78,7 @@ sam-build-all:
 ## sam-build: Builds assets for a specific SAM application, specified by APP variable
 sam-build:
 	$(call check_var,APP)
+	echo "VERSION=${VERSION}" > ${BUILD_MAKEFILE_ENV_VARS}
 	sam build \
 		--template-file apps/$(APP)/template.yaml \
 		--build-dir $(SAM_BUILD_DIR)/$(APP)/$(AWS_REGION) \
@@ -166,7 +168,7 @@ sam-publish-all:
 build-App:
 	$(call check_var,APP)
 	$(call check_var,ARTIFACTS_DIR)
-	GOARCH=arm64 GOOS=linux go build -tags lambda.norpc -o ./bootstrap cmd/$(APP)/main.go
+	GOARCH=arm64 GOOS=linux go build -tags lambda.norpc -ldflags "-X $(shell go list -m)/version.Version=${VERSION}" -o ./bootstrap cmd/$(APP)/main.go
 	cp ./bootstrap $(ARTIFACTS_DIR)/.
 
 build-Forwarder:

--- a/cmd/forwarder/main.go
+++ b/cmd/forwarder/main.go
@@ -15,11 +15,11 @@ import (
 	"github.com/observeinc/aws-sam-apps/handler/forwarder/override"
 	"github.com/observeinc/aws-sam-apps/logging"
 	"github.com/observeinc/aws-sam-apps/tracing"
+	"github.com/observeinc/aws-sam-apps/version"
 )
 
 const (
-	instrumentationName    = "github.com/observeinc/aws-sam-apps/cmd/forwarder"
-	instrumentationVersion = "0.1.0"
+	instrumentationName = "github.com/observeinc/aws-sam-apps/cmd/forwarder"
 )
 
 var env struct {
@@ -76,7 +76,7 @@ func realInit() (err error) {
 
 	tracer := tracerProvider.Tracer(
 		instrumentationName,
-		trace.WithInstrumentationVersion(instrumentationVersion),
+		trace.WithInstrumentationVersion(version.Version),
 	)
 
 	ctx, span := tracer.Start(ctx, "realInit")

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,5 @@
+package version
+
+// Version is the app-global version string, which should be substituted with a
+// real value during build.
+var Version = "UNKNOWN"


### PR DESCRIPTION
We want to set the version at build time. Unfortunately, the `sam build` command makes this slightly convoluted, given it executes `make build-${Resource}` without inheriting any of the variables passed into our original `make sam-build` call.

As a workaround, we stash the desired version in a file and source it back in. This is inherently race-y, since concurrent builds may overwite the file repeatedly. This risk should be fine for the time being, since we're always writing the same version value and we currently build serially.