### PR TITLE
feat(forwarder): handle records concurrently

### DIFF
--- a/handler/forwarder/config.go
+++ b/handler/forwarder/config.go
@@ -20,6 +20,7 @@ type Config struct {
 	Override          Override
 	S3Client          S3Client
 	GetTime           func() *time.Time
+	MaxConcurrency    int // fan out limit
 }
 
 func (c *Config) Validate() error {

--- a/handler/forwarder/message.go
+++ b/handler/forwarder/message.go
@@ -22,7 +22,7 @@ type CopyEvent struct {
 	Copy []CopyRecord `json:"copy"`
 }
 
-func (m *SQSMessage) GetObjectCreated() (copyRecords []CopyRecord) {
+func GetObjectCreated(m *events.SQSMessage) (copyRecords []CopyRecord) {
 	message := []byte(m.Body)
 
 	var snsEntity events.SNSEntity

--- a/handler/forwarder/message_test.go
+++ b/handler/forwarder/message_test.go
@@ -135,7 +135,7 @@ func TestObjectCreated(t *testing.T) {
 			}
 
 			// Directly compare the CopyRecords obtained from GetObjectCreated
-			copyRecords := message.GetObjectCreated()
+			copyRecords := forwarder.GetObjectCreated(&message.SQSMessage)
 			if diff := cmp.Diff(copyRecords, tc.Expected); diff != "" {
 				t.Errorf("unexpected result: %s", diff)
 			}

--- a/handler/forwarder/testdata/event.json
+++ b/handler/forwarder/testdata/event.json
@@ -1,21 +1,21 @@
 {
-    "Records": [
-        {
-            "messageId": "6aa4e980-26f6-46f4-bb73-fa6e82257191",
-            "receiptHandle": "AQEBdiYF/uR3IpR5MARpzj0ELM7jWFWuuRoei5gup23IMOTSOT8tJB+i3yTl7oykC/UGx7S8bVs+oFkYi8oeK8SANvAYzudqi7WjrXpJMaQfHhebNemzKsBGQg/NRPSOUc+s12APZAp/6r/uGH2K8dBeQuXCD4j2x8w3356cUJ6Iy/sVUvY+KzxP6x7poz+89nQOqFS6g7JS5KVRlDlEpyAdrVGD9kaDI47gQ49A/SlbSwDCBP3AekiyY2gzI4sbPRdhAO0GMpSiNENKcBCgEcaJD6uh7QwnD+NcdF7IO5XktokrKdG7OeoHgKFNQ06nWZDTzxZTLJrk2sEK+Ta5objqGWCRd0PhTMlZNXRd5aEmYimd+1zLBciY1H/yOzUkVQ0cXYmSJ7q8VYk5goF+FBlUXEeImPXbD+E8p4yOtFp7QIRBzmPm3so7onJGXr7g5++I",
-            "body": "{\"Records\":[{\"eventVersion\":\"2.1\",\"eventSource\":\"aws:s3\",\"awsRegion\":\"us-west-2\",\"eventTime\":\"2023-09-19T03:49:59.565Z\",\"eventName\":\"ObjectCreated:Put\",\"userIdentity\":{\"principalId\":\"AWS:AIDA2YN7JF3XJWA6ZRUAE\"},\"requestParameters\":{\"sourceIPAddress\":\"192.184.182.96\"},\"responseElements\":{\"x-amz-request-id\":\"2PSYP94SQN8SDTJE\",\"x-amz-id-2\":\"uL6hVdR9zmVu2Alc0ZXeqnUiHq80WZsEmBj98oY2SX6r5T4Kc3NE6RKn9VjbiQAXGDZ5dKKPp++u+K7mSYJNI/Ai/aW5E5at\"},\"s3\":{\"s3SchemaVersion\":\"1.0\",\"configurationId\":\"tf-s3-queue-20230829163550234000000002\",\"bucket\":{\"name\":\"observeinc-filedrop-hoho-us-west-2-7xmjt\",\"ownerIdentity\":{\"principalId\":\"A21JCN1A8EHLG1\"},\"arn\":\"arn:aws:s3:::observeinc-filedrop-hoho-us-west-2-7xmjt\"},\"object\":{\"key\":\"ds101/test3.json\",\"size\":16,\"eTag\":\"ed818579e8cee1d812a77f19efa5e56a\",\"versionId\":\"gv3S8Vnq7asERIoRjci5ssZkjTCjbVjY\",\"sequencer\":\"0065091A67786DA574\"}}}]}",
-            "attributes": {
-                "ApproximateReceiveCount": "3",
-                "SentTimestamp": "1695095400530",
-                "SenderId": "AIDAJFWZWTE5KRAMGW5A2",
-                "ApproximateFirstReceiveTimestamp": "1695095400531"
-            },
-            "messageAttributes": {},
-            "md5OfMessageAttributes": null,
-            "md5OfBody": "b0a876f5ce4a6e24a1ea1db02ea02bd3",
-            "eventSource": "aws:sqs",
-            "eventSourceARN": "arn:aws:sqs:us-west-2:739672403694:observeinc-filedrop-hoho-us-west-2-7xmjt",
-            "awsRegion": "us-west-2"
-        }
-    ]
+  "Records": [
+    {
+      "messageId": "6aa4e980-26f6-46f4-bb73-fa6e82257191",
+      "receiptHandle": "AQEBdiYF/uR3IpR5MARpzj0ELM7jWFWuuRoei5gup23IMOTSOT8tJB+i3yTl7oykC/UGx7S8bVs+oFkYi8oeK8SANvAYzudqi7WjrXpJMaQfHhebNemzKsBGQg/NRPSOUc+s12APZAp/6r/uGH2K8dBeQuXCD4j2x8w3356cUJ6Iy/sVUvY+KzxP6x7poz+89nQOqFS6g7JS5KVRlDlEpyAdrVGD9kaDI47gQ49A/SlbSwDCBP3AekiyY2gzI4sbPRdhAO0GMpSiNENKcBCgEcaJD6uh7QwnD+NcdF7IO5XktokrKdG7OeoHgKFNQ06nWZDTzxZTLJrk2sEK+Ta5objqGWCRd0PhTMlZNXRd5aEmYimd+1zLBciY1H/yOzUkVQ0cXYmSJ7q8VYk5goF+FBlUXEeImPXbD+E8p4yOtFp7QIRBzmPm3so7onJGXr7g5++I",
+      "body": "{\"Records\":[{\"eventVersion\":\"2.1\",\"eventSource\":\"aws:s3\",\"awsRegion\":\"us-west-2\",\"eventTime\":\"2023-09-19T03:49:59.565Z\",\"eventName\":\"ObjectCreated:Put\",\"userIdentity\":{\"principalId\":\"AWS:AIDA2YN7JF3XJWA6ZRUAE\"},\"requestParameters\":{\"sourceIPAddress\":\"192.184.182.96\"},\"responseElements\":{\"x-amz-request-id\":\"2PSYP94SQN8SDTJE\",\"x-amz-id-2\":\"uL6hVdR9zmVu2Alc0ZXeqnUiHq80WZsEmBj98oY2SX6r5T4Kc3NE6RKn9VjbiQAXGDZ5dKKPp++u+K7mSYJNI/Ai/aW5E5at\"},\"s3\":{\"s3SchemaVersion\":\"1.0\",\"configurationId\":\"tf-s3-queue-20230829163550234000000002\",\"bucket\":{\"name\":\"observeinc-filedrop-hoho-us-west-2-7xmjt\",\"ownerIdentity\":{\"principalId\":\"A21JCN1A8EHLG1\"},\"arn\":\"arn:aws:s3:::observeinc-filedrop-hoho-us-west-2-7xmjt\"},\"object\":{\"key\":\"ds101/test3.json\",\"size\":16,\"eTag\":\"ed818579e8cee1d812a77f19efa5e56a\",\"versionId\":\"gv3S8Vnq7asERIoRjci5ssZkjTCjbVjY\",\"sequencer\":\"0065091A67786DA574\"}}}]}",
+      "attributes": {
+        "ApproximateReceiveCount": "3",
+        "SentTimestamp": "1695095400530",
+        "SenderId": "AIDAJFWZWTE5KRAMGW5A2",
+        "ApproximateFirstReceiveTimestamp": "1695095400531"
+      },
+      "messageAttributes": {},
+      "md5OfMessageAttributes": null,
+      "md5OfBody": "b0a876f5ce4a6e24a1ea1db02ea02bd3",
+      "eventSource": "aws:sqs",
+      "eventSourceARN": "arn:aws:sqs:us-west-2:739672403694:observeinc-filedrop-hoho-us-west-2-7xmjt",
+      "awsRegion": "us-west-2"
+    }
+  ]
 }

--- a/handler/forwarder/testdata/multiple-records.json
+++ b/handler/forwarder/testdata/multiple-records.json
@@ -1,0 +1,56 @@
+{
+  "Records": [
+    {
+      "messageId": "6aa4e980-26f6-46f4-bb73-fa6e82257191",
+      "receiptHandle": "AQEBdiYF/uR3IpR5MARpzj0ELM7jWFWuuRoei5gup23IMOTSOT8tJB+i3yTl7oykC/UGx7S8bVs+oFkYi8oeK8SANvAYzudqi7WjrXpJMaQfHhebNemzKsBGQg/NRPSOUc+s12APZAp/6r/uGH2K8dBeQuXCD4j2x8w3356cUJ6Iy/sVUvY+KzxP6x7poz+89nQOqFS6g7JS5KVRlDlEpyAdrVGD9kaDI47gQ49A/SlbSwDCBP3AekiyY2gzI4sbPRdhAO0GMpSiNENKcBCgEcaJD6uh7QwnD+NcdF7IO5XktokrKdG7OeoHgKFNQ06nWZDTzxZTLJrk2sEK+Ta5objqGWCRd0PhTMlZNXRd5aEmYimd+1zLBciY1H/yOzUkVQ0cXYmSJ7q8VYk5goF+FBlUXEeImPXbD+E8p4yOtFp7QIRBzmPm3so7onJGXr7g5++I",
+      "body": "{\"Records\":[{\"eventVersion\":\"2.1\",\"eventSource\":\"aws:s3\",\"awsRegion\":\"us-west-2\",\"eventTime\":\"2023-09-19T03:49:59.565Z\",\"eventName\":\"ObjectCreated:Put\",\"userIdentity\":{\"principalId\":\"AWS:AIDA2YN7JF3XJWA6ZRUAE\"},\"requestParameters\":{\"sourceIPAddress\":\"192.184.182.96\"},\"responseElements\":{\"x-amz-request-id\":\"2PSYP94SQN8SDTJE\",\"x-amz-id-2\":\"uL6hVdR9zmVu2Alc0ZXeqnUiHq80WZsEmBj98oY2SX6r5T4Kc3NE6RKn9VjbiQAXGDZ5dKKPp++u+K7mSYJNI/Ai/aW5E5at\"},\"s3\":{\"s3SchemaVersion\":\"1.0\",\"configurationId\":\"tf-s3-queue-20230829163550234000000002\",\"bucket\":{\"name\":\"observeinc-filedrop-hoho-us-west-2-7xmjt\",\"ownerIdentity\":{\"principalId\":\"A21JCN1A8EHLG1\"},\"arn\":\"arn:aws:s3:::observeinc-filedrop-hoho-us-west-2-7xmjt\"},\"object\":{\"key\":\"ds101/test3.json\",\"size\":16,\"eTag\":\"ed818579e8cee1d812a77f19efa5e56a\",\"versionId\":\"gv3S8Vnq7asERIoRjci5ssZkjTCjbVjY\",\"sequencer\":\"0065091A67786DA574\"}}}]}",
+      "attributes": {
+        "ApproximateReceiveCount": "3",
+        "SentTimestamp": "1695095400530",
+        "SenderId": "AIDAJFWZWTE5KRAMGW5A2",
+        "ApproximateFirstReceiveTimestamp": "1695095400531"
+      },
+      "messageAttributes": {},
+      "md5OfMessageAttributes": null,
+      "md5OfBody": "b0a876f5ce4a6e24a1ea1db02ea02bd3",
+      "eventSource": "aws:sqs",
+      "eventSourceARN": "arn:aws:sqs:us-west-2:739672403694:observeinc-filedrop-hoho-us-west-2-7xmjt",
+      "awsRegion": "us-west-2"
+    },
+    {
+      "messageId": "6aa4e980-26f6-46f4-bb73-fa6e82257192",
+      "receiptHandle": "AQEBdiYF/uR3IpR5MARpzj0ELM7jWFWuuRoei5gup23IMOTSOT8tJB+i3yTl7oykC/UGx7S8bVs+oFkYi8oeK8SANvAYzudqi7WjrXpJMaQfHhebNemzKsBGQg/NRPSOUc+s12APZAp/6r/uGH2K8dBeQuXCD4j2x8w3356cUJ6Iy/sVUvY+KzxP6x7poz+89nQOqFS6g7JS5KVRlDlEpyAdrVGD9kaDI47gQ49A/SlbSwDCBP3AekiyY2gzI4sbPRdhAO0GMpSiNENKcBCgEcaJD6uh7QwnD+NcdF7IO5XktokrKdG7OeoHgKFNQ06nWZDTzxZTLJrk2sEK+Ta5objqGWCRd0PhTMlZNXRd5aEmYimd+1zLBciY1H/yOzUkVQ0cXYmSJ7q8VYk5goF+FBlUXEeImPXbD+E8p4yOtFp7QIRBzmPm3so7onJGXr7g5++I",
+      "body": "{\"Records\":[{\"eventVersion\":\"2.1\",\"eventSource\":\"aws:s3\",\"awsRegion\":\"us-west-2\",\"eventTime\":\"2023-09-19T03:49:59.565Z\",\"eventName\":\"ObjectCreated:Put\",\"userIdentity\":{\"principalId\":\"AWS:AIDA2YN7JF3XJWA6ZRUAE\"},\"requestParameters\":{\"sourceIPAddress\":\"192.184.182.96\"},\"responseElements\":{\"x-amz-request-id\":\"2PSYP94SQN8SDTJE\",\"x-amz-id-2\":\"uL6hVdR9zmVu2Alc0ZXeqnUiHq80WZsEmBj98oY2SX6r5T4Kc3NE6RKn9VjbiQAXGDZ5dKKPp++u+K7mSYJNI/Ai/aW5E5at\"},\"s3\":{\"s3SchemaVersion\":\"1.0\",\"configurationId\":\"tf-s3-queue-20230829163550234000000002\",\"bucket\":{\"name\":\"observeinc-filedrop-hoho-us-west-2-7xmjt\",\"ownerIdentity\":{\"principalId\":\"A21JCN1A8EHLG1\"},\"arn\":\"arn:aws:s3:::observeinc-filedrop-hoho-us-west-2-7xmjt\"},\"object\":{\"key\":\"ds101/test3.json\",\"size\":16,\"eTag\":\"ed818579e8cee1d812a77f19efa5e56a\",\"versionId\":\"gv3S8Vnq7asERIoRjci5ssZkjTCjbVjY\",\"sequencer\":\"0065091A67786DA574\"}}}]}",
+      "attributes": {
+        "ApproximateReceiveCount": "3",
+        "SentTimestamp": "1695095400530",
+        "SenderId": "AIDAJFWZWTE5KRAMGW5A2",
+        "ApproximateFirstReceiveTimestamp": "1695095400531"
+      },
+      "messageAttributes": {},
+      "md5OfMessageAttributes": null,
+      "md5OfBody": "b0a876f5ce4a6e24a1ea1db02ea02bd3",
+      "eventSource": "aws:sqs",
+      "eventSourceARN": "arn:aws:sqs:us-west-2:739672403694:observeinc-filedrop-hoho-us-west-2-7xmjt",
+      "awsRegion": "us-west-2"
+    },
+    {
+      "messageId": "6aa4e980-26f6-46f4-bb73-fa6e82257193",
+      "receiptHandle": "AQEBdiYF/uR3IpR5MARpzj0ELM7jWFWuuRoei5gup23IMOTSOT8tJB+i3yTl7oykC/UGx7S8bVs+oFkYi8oeK8SANvAYzudqi7WjrXpJMaQfHhebNemzKsBGQg/NRPSOUc+s12APZAp/6r/uGH2K8dBeQuXCD4j2x8w3356cUJ6Iy/sVUvY+KzxP6x7poz+89nQOqFS6g7JS5KVRlDlEpyAdrVGD9kaDI47gQ49A/SlbSwDCBP3AekiyY2gzI4sbPRdhAO0GMpSiNENKcBCgEcaJD6uh7QwnD+NcdF7IO5XktokrKdG7OeoHgKFNQ06nWZDTzxZTLJrk2sEK+Ta5objqGWCRd0PhTMlZNXRd5aEmYimd+1zLBciY1H/yOzUkVQ0cXYmSJ7q8VYk5goF+FBlUXEeImPXbD+E8p4yOtFp7QIRBzmPm3so7onJGXr7g5++I",
+      "body": "{\"Records\":[{\"eventVersion\":\"2.1\",\"eventSource\":\"aws:s3\",\"awsRegion\":\"us-west-2\",\"eventTime\":\"2023-09-19T03:49:59.565Z\",\"eventName\":\"ObjectCreated:Put\",\"userIdentity\":{\"principalId\":\"AWS:AIDA2YN7JF3XJWA6ZRUAE\"},\"requestParameters\":{\"sourceIPAddress\":\"192.184.182.96\"},\"responseElements\":{\"x-amz-request-id\":\"2PSYP94SQN8SDTJE\",\"x-amz-id-2\":\"uL6hVdR9zmVu2Alc0ZXeqnUiHq80WZsEmBj98oY2SX6r5T4Kc3NE6RKn9VjbiQAXGDZ5dKKPp++u+K7mSYJNI/Ai/aW5E5at\"},\"s3\":{\"s3SchemaVersion\":\"1.0\",\"configurationId\":\"tf-s3-queue-20230829163550234000000002\",\"bucket\":{\"name\":\"observeinc-filedrop-hoho-us-west-2-7xmjt\",\"ownerIdentity\":{\"principalId\":\"A21JCN1A8EHLG1\"},\"arn\":\"arn:aws:s3:::observeinc-filedrop-hoho-us-west-2-7xmjt\"},\"object\":{\"key\":\"ds101/test3.json\",\"size\":16,\"eTag\":\"ed818579e8cee1d812a77f19efa5e56a\",\"versionId\":\"gv3S8Vnq7asERIoRjci5ssZkjTCjbVjY\",\"sequencer\":\"0065091A67786DA574\"}}}]}",
+      "attributes": {
+        "ApproximateReceiveCount": "3",
+        "SentTimestamp": "1695095400530",
+        "SenderId": "AIDAJFWZWTE5KRAMGW5A2",
+        "ApproximateFirstReceiveTimestamp": "1695095400531"
+      },
+      "messageAttributes": {},
+      "md5OfMessageAttributes": null,
+      "md5OfBody": "b0a876f5ce4a6e24a1ea1db02ea02bd3",
+      "eventSource": "aws:sqs",
+      "eventSourceARN": "arn:aws:sqs:us-west-2:739672403694:observeinc-filedrop-hoho-us-west-2-7xmjt",
+      "awsRegion": "us-west-2"
+    }
+
+  ]
+}


### PR DESCRIPTION
Copying large objects can take a while when executing across regions. This commit ensures we handle each SQS record concurrently, which should be safe since:
- `s3:CopyObject` does not consume lambda resources, so we are not at risk of running out of memory / cpu
- our fan out factor is capped by our batch size on the SQS queue, which is quite small when compared to the AWS API limits.

Each SQS record itself may contain a list of files to copy. This list is still processed serially for now. In practice we do not use this capability yet.