### PR TITLE
fix(forwarder): increase timeout

### DIFF
--- a/apps/forwarder/template.yaml
+++ b/apps/forwarder/template.yaml
@@ -36,7 +36,7 @@ Metadata:
 
 Globals:
   Function:
-    Timeout: 20
+    Timeout: 300
     MemorySize: 128
 
 Parameters:
@@ -140,7 +140,7 @@ Resources:
       RedrivePolicy:
         deadLetterTargetArn: !GetAtt DeadLetter.Arn
         maxReceiveCount: 4
-      VisibilityTimeout: 20
+      VisibilityTimeout: 300
   QueuePolicy:
     Type: AWS::SQS::QueuePolicy
     Properties:

--- a/integration/tests/firehose.tftest.hcl
+++ b/integration/tests/firehose.tftest.hcl
@@ -13,6 +13,7 @@ variables {
           "firehose:DeleteDeliveryStream",
           "firehose:DescribeDeliveryStream",
           "firehose:ListTagsForDeliveryStream",
+          "firehose:TagDeliveryStream",
           "firehose:UpdateDestination",
           "iam:AttachRolePolicy",
           "iam:CreateRole",


### PR DESCRIPTION
The duration of `CopyObject` depends on file size and source and destination region. In order to account for large files, we need to increase our lambda timeout value.