### PR TITLE
fix(metricstream): update permissions

### DIFF
--- a/integration/tests/metricstream.tftest.hcl
+++ b/integration/tests/metricstream.tftest.hcl
@@ -19,6 +19,7 @@ variables {
           "firehose:DeleteDeliveryStream",
           "firehose:DescribeDeliveryStream",
           "firehose:ListTagsForDeliveryStream",
+          "firehose:TagDeliveryStream",
           "firehose:UpdateDestination",
           "iam:AttachRolePolicy",
           "iam:CreateRole",


### PR DESCRIPTION
Surprisingly this was caught in CI out of nowhere:

```
│ Error: waiting for CloudFormation Stack (arn:aws:cloudformation:us-west-2:091720823232:stack/well-monarch-3b75b1bad4a9701d888aa07ec6c027eed549be6681f7a0fa5b2cc15e63e5c28896430d5d812226447072a657e699e6fb246a680f8b1f98e6d9e/da532300-fe7e-11ee-bdc8-06c2ef2a1519) create: failed to create CloudFormation stack, rollback requested (ROLLBACK_COMPLETE): ["The following resource(s) failed to create: [DeliveryStream]. Rollback requested by user." "User: arn:aws:sts::091720823232:assumed-role/well-monarch-3b75b1bad4a9701d888-20240419185846892400000001/AWSCloudFormation is not authorized to perform: firehose:TagDeliveryStream on resource: arn:aws:firehose:us-west-2:091720823232:deliverystream/well-monarch-3b75b1bad4a9701d888aa07ec6c027eed549be6681f7a0fa5b2 because no identity-based policy allows the firehose:TagDeliveryStream action (Service: Firehose, Status Code: 400, Request ID: c6f29239-e0c8-e486-986e-53e9891e957e, Extended Request ID: 8pMEwpXK9ZiHHG74fSsvrH7r72HkJH7SYIP5UogRPS4j711upAivsC+5wLgqZRXWWANct+HK84QOeOUA5L0k0aiNpwDAQfF9)"]
```