### PR TITLE
feat(forwarder): add inference presets

### DIFF
--- a/cmd/forwarder/main.go
+++ b/cmd/forwarder/main.go
@@ -27,7 +27,7 @@ var env struct {
 	Verbosity            int              `env:"VERBOSITY,default=1"`
 	MaxFileSize          int64            `env:"MAX_FILE_SIZE"`
 	ContentTypeOverrides []*override.Rule `env:"CONTENT_TYPE_OVERRIDES"`
-	PresetOverrides      []string         `env:"PRESET_OVERRIDES,default=aws/v1"`
+	PresetOverrides      []string         `env:"PRESET_OVERRIDES,default=aws/v1,infer/v1"`
 	SourceBucketNames    []string         `env:"SOURCE_BUCKET_NAMES"`
 
 	OTELServiceName          string `env:"OTEL_SERVICE_NAME,default=forwarder"`

--- a/handler/forwarder/override/presets/infer/v1.yaml
+++ b/handler/forwarder/override/presets/infer/v1.yaml
@@ -1,0 +1,38 @@
+- id: stripOctetStream
+  match:
+    # these content types don't map to anything, remove them and infer
+    content-type: '(binary/octet-stream|application/octet-stream)'
+  override:
+    content-type: ''
+  continue: true
+- id: gzip
+  match:
+    source: '.gz$'
+    content-encoding: '^$'
+  override:
+    content-encoding: 'gzip'
+  continue: true
+- id: json
+  match:
+    source: 'json'
+    content-type: '^$'
+  override:
+    content-type: 'application/json'
+- id: parquet
+  match:
+    source: 'parquet'
+    content-type: '^$'
+  override:
+    content-type: 'application/vnd.apache.parquet'
+- id: csv
+  match:
+    source: 'csv'
+    content-type: '^$'
+  override:
+    content-type: 'text/csv'
+- id: txt
+  match:
+    source: 'txt'
+    content-type: '^$'
+  override:
+    content-type: 'text/plain'

--- a/handler/forwarder/override/presets_test.go
+++ b/handler/forwarder/override/presets_test.go
@@ -74,6 +74,46 @@ func TestPresets(t *testing.T) {
 				},
 			},
 		},
+		{
+			Presets: []string{"aws/v1", "infer/v1"},
+			Expect: []VerifyApply{
+				{
+					Input: &s3.CopyObjectInput{
+						CopySource:  aws.String("test-bucket/hohoho.json.gz"),
+						ContentType: aws.String("binary/octet-stream"),
+					},
+					Expect: &s3.CopyObjectInput{
+						CopySource:        aws.String("test-bucket/hohoho.json.gz"),
+						ContentType:       aws.String("application/json"),
+						ContentEncoding:   aws.String("gzip"),
+						MetadataDirective: types.MetadataDirectiveReplace,
+					},
+				},
+				{
+					Input: &s3.CopyObjectInput{
+						CopySource:  aws.String("test-bucket/hohoho.json.gz"),
+						ContentType: aws.String("text/csv"),
+					},
+					Expect: &s3.CopyObjectInput{
+						CopySource:        aws.String("test-bucket/hohoho.json.gz"),
+						ContentType:       aws.String("text/csv"),
+						ContentEncoding:   aws.String("gzip"),
+						MetadataDirective: types.MetadataDirectiveReplace,
+					},
+				},
+				{
+					Input: &s3.CopyObjectInput{
+						CopySource:  aws.String("test-bucket/hohoho.parquet"),
+						ContentType: aws.String("application/octet-stream"),
+					},
+					Expect: &s3.CopyObjectInput{
+						CopySource:        aws.String("test-bucket/hohoho.parquet"),
+						ContentType:       aws.String("application/vnd.apache.parquet"),
+						MetadataDirective: types.MetadataDirectiveReplace,
+					},
+				},
+			},
+		},
 	}
 
 	for i, tc := range testcases {

--- a/integration/tests/logwriter.tftest.hcl
+++ b/integration/tests/logwriter.tftest.hcl
@@ -20,6 +20,7 @@ variables {
           "firehose:DeleteDeliveryStream",
           "firehose:DescribeDeliveryStream",
           "firehose:ListTagsForDeliveryStream",
+          "firehose:TagDeliveryStream",
           "firehose:UpdateDestination",
           "iam:AttachRolePolicy",
           "iam:CreateRole",

--- a/integration/tests/stack.tftest.hcl
+++ b/integration/tests/stack.tftest.hcl
@@ -35,6 +35,7 @@ variables {
           "firehose:DeleteDeliveryStream",
           "firehose:DescribeDeliveryStream",
           "firehose:ListTagsForDeliveryStream",
+          "firehose:TagDeliveryStream",
           "firehose:UpdateDestination",
           "iam:AttachRolePolicy",
           "iam:CreateRole",


### PR DESCRIPTION
In the case where no content type is set, we can try to infer based on the filename. We should also attempt inference when confronted with content types that don't signal what the type actually is (e.g. `binary/octet-stream`).