### PR TITLE
feat: introduce ability to ignore files

### DIFF
--- a/handler/forwarder/override/presets/aws/v1.yaml
+++ b/handler/forwarder/override/presets/aws/v1.yaml
@@ -41,3 +41,8 @@
   override:
     content-type: 'application/x-aws-vpcflowlogs'
 
+- id: awsTestObject
+  match:
+    source: 'aws-programmatic-access-test-object$'
+  override:
+    content-type: 'text/x-ignore'

--- a/handler/forwarder/override/presets_test.go
+++ b/handler/forwarder/override/presets_test.go
@@ -72,6 +72,17 @@ func TestPresets(t *testing.T) {
 						MetadataDirective: types.MetadataDirectiveReplace,
 					},
 				},
+				{
+					Input: &s3.CopyObjectInput{
+						CopySource: aws.String("test-bucket/aws-programmatic-access-test-object"),
+						Key:        aws.String("ds1011011/aws-programmatic-access-test-object"),
+					},
+					Expect: &s3.CopyObjectInput{
+						CopySource: aws.String("test-bucket/aws-programmatic-access-test-object"),
+						// file will not be copied over
+						Key: nil,
+					},
+				},
 			},
 		},
 		{


### PR DESCRIPTION
We often don't have control of what is writing into a source bucket. As an example, AWS writes an `aws-programmatic-access-test-object` file with content-type `application/octet-stream`. Filename inference is not able to adequately detect that this is a simple text file, and in any case we don't even want to ingest it.

This commit adds the ability to add a content type override that disables forwarding for matches files. If a content type is set to `text/x-ignore`, we will not forward the file.

This is a dubious overloading of the content type field, but it is the most practical given our configuration constraints. We are currently surfacing content type overrides consistently in terraform and cloudformation. Adding a separate variable to capture what files should be forwarded would add unnecessary complexity to our onboarding.