### PR TITLE
feat(stack): auto-subscribe to AWS Config

### DIFF
--- a/apps/configsubscription/README.md
+++ b/apps/configsubscription/README.md
@@ -1,0 +1,3 @@
+# AWS Config Subscription
+
+[docs/configsubscription.md](../docs/configsubscription.md)

--- a/apps/configsubscription/template.yaml
+++ b/apps/configsubscription/template.yaml
@@ -1,0 +1,78 @@
+---
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: >
+  A stack to subscribe AWS Config events
+
+Metadata:
+  AWS::ServerlessRepo::Application:
+    Name: observe-aws-config-subscription
+    Description: A stack to subscribe AWS Config events
+    Author: Observe Inc
+    SpdxLicenseId: Apache-2.0
+    ReadmeUrl: README.md
+    HomePageUrl: https://github.com/observeinc/aws-sam-apps
+    SemanticVersion: 0.0.4
+    SourceCodeUrl: https://github.com/observeinc/aws-sam-apps
+
+Parameters:
+  TargetARN:
+    Type: String
+    Description: >-
+      Where to forward EventBridge events.
+    AllowedPattern: "^(arn:.*)?$"
+
+Resources:
+  CopyRule:
+    Type: AWS::Events::Rule
+    Properties:
+      Description: "Copy AWS Config files"
+      EventPattern:
+        source:
+          - "aws.config"
+        detail-type:
+          - "Config Configuration History Delivery Status"
+          - "Config Configuration Snapshot Delivery Status"
+        detail:
+          messageType:
+            - "ConfigurationHistoryDeliveryCompleted"
+            - "ConfigurationSnapshotDeliveryCompleted"
+      Targets:
+        - Arn: !Ref TargetARN
+          Id: "AWSConfigDelivery"
+          InputTransformer:
+            InputPathsMap:
+              bucketName: "$.detail.s3Bucket"
+              objectKey: "$.detail.s3ObjectKey"
+            InputTemplate: >-
+              {"copy": [{"uri": "s3://<bucketName>/<objectKey>"}]}
+  OverizedCopyRule:
+    Type: AWS::Events::Rule
+    Properties:
+      Description: "Copy AWS Config oversized events"
+      EventPattern:
+        source:
+          - "aws.config"
+        detail:
+          messageType:
+            - "OversizedConfigurationItemChangeNotification"
+      Targets:
+        - Arn: !Ref TargetARN
+          Id: "AWSConfigOversizedDelivery"
+          InputTransformer:
+            InputPathsMap:
+              location: "$.detail.s3DeliverySummary.s3BucketLocation"
+            InputTemplate: >-
+              {"copy": [{"uri": "s3://<location>"}]}
+  ChangeRule:
+    Type: AWS::Events::Rule
+    Properties:
+      Description: "Forward AWS Config change notifications"
+      EventPattern:
+        source:
+          - "aws.config"
+        detail-type:
+          - "Config Configuration Item Change"
+      Targets:
+        - Arn: !Ref TargetARN
+          Id: "AWSConfigChange"

--- a/apps/stack/template.yaml
+++ b/apps/stack/template.yaml
@@ -258,6 +258,17 @@ Resources:
         TopicARN: !Ref Topic
         IncludeResourceTypes: !Join [",", !Ref IncludeResourceTypes]
         ExcludeResourceTypes: !Join [",", !Ref ExcludeResourceTypes]
+  ConfigSubscription:
+    Type: AWS::Serverless::Application
+    Condition: EnableConfigSubscription
+    Properties:
+      Location: ../configsubscription/template.yaml
+      NotificationARNs:
+        - !Ref Topic
+      Parameters:
+        TargetARN: !GetAtt
+          - Forwarder
+          - Outputs.Queue
   LogWriter:
     Type: AWS::Serverless::Application
     Properties:
@@ -289,45 +300,6 @@ Resources:
           - UseStackName
           - !Sub "${AWS::StackName}-MetricStream"
           - !Sub "${NameOverride}-MetricStream"
-  CopyConfigRule:
-    Type: AWS::Events::Rule
-    Condition: EnableConfigSubscription
-    Properties:
-      Description: "Copy AWS Config files"
-      EventPattern:
-        source:
-          - "aws.config"
-        detail-type:
-          - "Config Configuration History Delivery Status"
-          - "Config Configuration Snapshot Delivery Status"
-        detail:
-          messageType:
-            - "ConfigurationHistoryDeliveryCompleted"
-            - "ConfigurationSnapshotDeliveryCompleted"
-      Targets:
-        - Arn: !GetAtt
-          - Forwarder
-          - Outputs.Queue
-          Id: "AWS Config Delivery"
-          InputTransformer:
-            InputPathsMap:
-              bucketName: "$.detail.s3Bucket"
-              objectKey: "$.detail.s3ObjectKey"
-            InputTemplate: >-
-              {"copy": [{"uri": "s3://<bucketName>/<objectKey>"}]}
-  ForwardConfigRule:
-    Type: AWS::Events::Rule
-    Condition: EnableConfigSubscription
-    Properties:
-      Description: "Forward AWS Config events"
-      EventPattern:
-        source:
-          - "aws.config"
-      Targets:
-        - Arn: !GetAtt
-          - Forwarder
-          - Outputs.Queue
-          Id: "AWS Config Events"
 Outputs:
   Bucket:
     Description: "S3 Bucket Name"

--- a/apps/stack/template.yaml
+++ b/apps/stack/template.yaml
@@ -24,6 +24,7 @@ Metadata:
       - Label:
           default: AWS Config
         Parameters:
+          - ConfigDeliveryBucketName
           - IncludeResourceTypes
           - ExcludeResourceTypes
       - Label:
@@ -79,12 +80,18 @@ Parameters:
       of this stack, and must therefore be unique within the account.
     Default: ""
     MaxLength: 51
+  ConfigDeliveryBucketName:
+    Type: String
+    Description: >-
+      If AWS Config is already enabled in this account and region, provide the
+      S3 bucket snapshots are written to.
+    Default: ""
   IncludeResourceTypes:
     Type: CommaDelimitedList
     Description: >-
-      Resources to collect using AWS Config. Use a wildcard to collect all
-      supported resource types. Do not set this parameter if AWS Config is
-      already installed for this region.
+      If AWS Config is not enabled in this account and region, provide a list of
+      resource types to collect. Use a wildcard to collect all
+      supported resource types.
     Default: ""
     AllowedPattern: '^([a-zA-Z0-9]+::[a-zA-Z0-9]+::[a-zA-Z0-9]+|\*)?$'
   ExcludeResourceTypes:
@@ -122,12 +129,20 @@ Parameters:
     AllowedPattern: "^(http(s)?:\/\/.*)?$"
 
 Conditions:
-  EnableConfig: !Not
-    - !Equals
-      - ""
-      - !Join
-        - ","
-        - !Ref IncludeResourceTypes
+  EmptyConfigDeliveryBucketName: !Equals
+    - !Ref ConfigDeliveryBucketName
+    - ""
+  EnableConfigSubscription: !Not
+   - !Condition EmptyConfigDeliveryBucketName
+  EnableConfig: !And
+    - !Not
+      - !Condition EnableConfigSubscription
+    - !Not
+      - !Equals
+        - ""
+        - !Join
+          - ","
+          - !Ref IncludeResourceTypes
   EmptySourceBucketNames: !Equals
     - !Join [",", !Ref SourceBucketNames]
     - ""
@@ -202,14 +217,17 @@ Resources:
       Parameters:
         DataAccessPointArn: !Ref DataAccessPointArn
         DestinationUri: !Ref DestinationUri
-        SourceBucketNames: 
-          !If
-            - EmptySourceBucketNames
-            - !Sub "${Bucket}"
-            - !Join 
-                - ","
-                - - !Ref Bucket
-                  - !Join [",", !Ref SourceBucketNames]
+        SourceBucketNames: !Join
+            - ","
+            - - !Ref Bucket
+              - !If
+                - EmptySourceBucketNames
+                - !Ref AWS::NoValue
+                - !Join [",", !Ref SourceBucketNames]
+              - !If
+                - EmptyConfigDeliveryBucketName
+                - !Ref AWS::NoValue
+                - !Ref ConfigDeliveryBucketName
         SourceTopicArns: !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:*"
         ContentTypeOverrides: !Join
           - ","
@@ -271,7 +289,45 @@ Resources:
           - UseStackName
           - !Sub "${AWS::StackName}-MetricStream"
           - !Sub "${NameOverride}-MetricStream"
-
+  CopyConfigRule:
+    Type: AWS::Events::Rule
+    Condition: EnableConfigSubscription
+    Properties:
+      Description: "Copy AWS Config files"
+      EventPattern:
+        source:
+          - "aws.config"
+        detail-type:
+          - "Config Configuration History Delivery Status"
+          - "Config Configuration Snapshot Delivery Status"
+        detail:
+          messageType:
+            - "ConfigurationHistoryDeliveryCompleted"
+            - "ConfigurationSnapshotDeliveryCompleted"
+      Targets:
+        - Arn: !GetAtt
+          - Forwarder
+          - Outputs.Queue
+          Id: "AWS Config Delivery"
+          InputTransformer:
+            InputPathsMap:
+              bucketName: "$.detail.s3Bucket"
+              objectKey: "$.detail.s3ObjectKey"
+            InputTemplate: >-
+              {"copy": [{"uri": "s3://<bucketName>/<objectKey>"}]}
+  ForwardConfigRule:
+    Type: AWS::Events::Rule
+    Condition: EnableConfigSubscription
+    Properties:
+      Description: "Forward AWS Config events"
+      EventPattern:
+        source:
+          - "aws.config"
+      Targets:
+        - Arn: !GetAtt
+          - Forwarder
+          - Outputs.Queue
+          Id: "AWS Config Events"
 Outputs:
   Bucket:
     Description: "S3 Bucket Name"

--- a/docs/configsubscription.md
+++ b/docs/configsubscription.md
@@ -1,0 +1,19 @@
+# Observe AWS Config Subscription Setup
+
+The Observe AWS Config subscription stack attempts to forward data for an existing AWS Config installation.
+
+## Overview
+
+This stack installs EventBridge rules which process events from AWS Config:
+
+- generates "copy" commands for events that denote a successful delivery of data to an S3 bucket
+- forward change notification events 
+
+
+## Configuration Parameters
+
+The stack supports the following parameters:
+
+| Parameter       | Type    | Description |
+|-----------------|---------|-------------|
+| **`TargetARN`** | String | Where to forward EventBridge events. |

--- a/docs/stack.md
+++ b/docs/stack.md
@@ -29,6 +29,7 @@ The Observe stack provisions the following components:
 | `SourceBucketNames` | CommaDelimitedList | A list of bucket names which the forwarder is allowed to read from. |
 | `ContentTypeOverrides` | CommaDelimitedList | A list of key value pairs. The key is a regular expression which is applied to the S3 source (<bucket>/<key>) of forwarded files. The value is the content type to set for matching files. For example, `\.json$=application/x-ndjson` would forward all files ending in `.json` as newline delimited JSON files. |
 | `NameOverride` | String | Name of IAM role expected by Filedrop. This role will be created as part of this stack, and must therefore be unique within the account. |
+| `ConfigDeliveryBucketName` | String | If AWS Config is already enabled in this account and region, provide the S3 bucket snapshots are written to. |
 | `IncludeResourceTypes` | CommaDelimitedList | Resources to collect using AWS Config. Use a wildcard to collect all supported resource types. Do not set this parameter if AWS Config is already installed for this region. |
 | `ExcludeResourceTypes` | CommaDelimitedList | Exclude a subset of resource types from configuration collection. This parameter can only be set if IncludeResourceTypes is wildcarded. |
 | `LogGroupNamePatterns` | CommaDelimitedList | Comma separated list of patterns. If not empty, the lambda function will only apply to log groups that have names that match one of the provided strings based on a case-sensitive substring search. |

--- a/integration/tests/configsubscription.tftest.hcl
+++ b/integration/tests/configsubscription.tftest.hcl
@@ -1,0 +1,53 @@
+variables {
+  install_policy_json = <<-EOF
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Action": [
+          "cloudformation:*",
+          "events:DeleteRule",
+          "events:DescribeRule",
+          "events:PutRule",
+          "events:PutTargets",
+          "events:RemoveTargets"
+        ],
+        "Resource": "*"
+      }
+    ]
+  }
+EOF
+}
+
+run "setup" {
+  module {
+    source  = "observeinc/collection/aws//modules/testing/setup"
+    version = "2.14.0"
+  }
+}
+
+run "target" {
+  module {
+    source  = "observeinc/collection/aws//modules/testing/sqs_queue"
+    version = "2.14.0"
+  }
+
+  variables {
+    setup = run.setup
+  }
+}
+
+
+run "install" {
+  variables {
+    setup = run.setup
+    app   = "configsubscription"
+    parameters = {
+      TargetARN = run.target.queue.arn
+    }
+    capabilities = [
+      "CAPABILITY_AUTO_EXPAND",
+    ]
+  }
+}

--- a/integration/tests/stack.tftest.hcl
+++ b/integration/tests/stack.tftest.hcl
@@ -155,10 +155,11 @@ run "install" {
     setup = run.setup
     app   = "stack"
     parameters = {
-      DataAccessPointArn   = run.create_bucket.access_point.arn
-      DestinationUri       = "s3://${run.create_bucket.access_point.alias}"
-      LogGroupNamePatterns = "*"
-      NameOverride         = run.setup.id
+      DataAccessPointArn       = run.create_bucket.access_point.arn
+      DestinationUri           = "s3://${run.create_bucket.access_point.alias}"
+      ConfigDeliveryBucketName = "example-bucket"
+      LogGroupNamePatterns     = "*"
+      NameOverride             = run.setup.id
     }
     capabilities = [
       "CAPABILITY_NAMED_IAM",


### PR DESCRIPTION
When enabled, AWS Config emits events to EventBridge. This opens the opportunity to ingest AWS Config data without having to manually subscribe an S3 bucket (for config history, snapshot and oversized notifications) and SNS Topic (for change notifications).

We add a new parameter, `ConfigDeliveryBucketName`, which gates whether to attempt to ingest config data. When present:

- we add the bucket to the source bucket list for our forwarder
- we add an eventbridge rule to construct copy commands for the forwarder on successful config delivery
- we add an eventbridge rule to forward all Config events