### PR TITLE
refactor(forwarder): refactor DecoderFactory

### DIFF
--- a/handler/forwarder/s3http/client.go
+++ b/handler/forwarder/s3http/client.go
@@ -122,13 +122,13 @@ func (c *Client) PutObject(ctx context.Context, params *s3.PutObjectInput, _ ...
 	logger := logr.FromContextOrDiscard(ctx)
 	logger.V(6).Info("processing PutObject", "putObjectInput", params)
 
-	dec, err := decoders.Get(aws.ToString(params.ContentEncoding), aws.ToString(params.ContentType))
+	dec, err := decoders.Get(aws.ToString(params.ContentEncoding), aws.ToString(params.ContentType), params.Body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get decoder: %w", err)
 	}
 
 	err = batch.Run(ctx, &batch.RunInput{
-		Decoder: dec(params.Body),
+		Decoder: dec,
 		Handler: c.RequestBuilder.With(map[string]string{
 			"content-type": aws.ToString(params.ContentType),
 			"key":          aws.ToString(params.Key),

--- a/handler/forwarder/s3http/internal/decoders/cloudwatch.go
+++ b/handler/forwarder/s3http/internal/decoders/cloudwatch.go
@@ -9,13 +9,11 @@ import (
 	"github.com/aws/aws-lambda-go/events"
 )
 
-func CloudWatchLogsDecoderFactory(map[string]string) DecoderFactory {
-	return func(r io.Reader) Decoder {
-		buffered := bufio.NewReader(r)
-		return &CloudWatchLogsDecoder{
-			buffered: buffered,
-			decoder:  json.NewDecoder(buffered),
-		}
+func CloudWatchLogsDecoderFactory(r io.Reader, _ map[string]string) Decoder {
+	buffered := bufio.NewReader(r)
+	return &CloudWatchLogsDecoder{
+		buffered: buffered,
+		decoder:  json.NewDecoder(buffered),
 	}
 }
 

--- a/handler/forwarder/s3http/internal/decoders/decoder.go
+++ b/handler/forwarder/s3http/internal/decoders/decoder.go
@@ -12,7 +12,7 @@ var (
 	ErrUnsupportedContentType     = errors.New("content type not supported: %w")
 )
 
-var decoders = map[string]ParameterizedDecoderFactory{
+var decoders = map[string]DecoderFactory{
 	"":                                    JSONDecoderFactory,
 	"application/json":                    JSONDecoderFactory,
 	"application/x-csv":                   CSVDecoderFactory,
@@ -34,11 +34,10 @@ type Decoder interface {
 }
 
 type (
-	ParameterizedDecoderFactory func(params map[string]string) DecoderFactory
-	DecoderFactory              func(io.Reader) Decoder
+	DecoderFactory func(io.Reader, map[string]string) Decoder
 )
 
-func Get(contentEncoding, contentType string) (DecoderFactory, error) {
+func Get(contentEncoding, contentType string, r io.Reader) (Decoder, error) {
 	wrapper, ok := wrappers[contentEncoding]
 	if !ok {
 		return nil, fmt.Errorf("%w: %q", ErrUnsupportedContentEncoding, contentEncoding)
@@ -54,5 +53,5 @@ func Get(contentEncoding, contentType string) (DecoderFactory, error) {
 		return nil, fmt.Errorf("%w: %q", ErrUnsupportedContentType, contentType)
 	}
 
-	return wrapper(decoder(params)), nil
+	return wrapper(decoder)(r, params), nil
 }

--- a/handler/forwarder/s3http/internal/decoders/decoder_test.go
+++ b/handler/forwarder/s3http/internal/decoders/decoder_test.go
@@ -62,7 +62,7 @@ func TestDecoders(t *testing.T) {
 		t.Run(tt.InputFile, func(t *testing.T) {
 			t.Parallel()
 
-			fn, err := decoders.Get(tt.ContentEncoding, tt.ContentType)
+			dec, err := decoders.Get(tt.ContentEncoding, tt.ContentType, readFile(t, tt.InputFile))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -70,7 +70,7 @@ func TestDecoders(t *testing.T) {
 			var buf bytes.Buffer
 
 			enc := json.NewEncoder(&buf)
-			for dec := fn(readFile(t, tt.InputFile)); dec.More(); {
+			for dec.More() {
 				var v json.RawMessage
 				if err := dec.Decode(&v); err != nil {
 					t.Fatal(err)

--- a/handler/forwarder/s3http/internal/decoders/json.go
+++ b/handler/forwarder/s3http/internal/decoders/json.go
@@ -6,27 +6,23 @@ import (
 	"io"
 )
 
-func JSONDecoderFactory(map[string]string) DecoderFactory {
-	return func(r io.Reader) Decoder {
-		return json.NewDecoder(r)
-	}
+func JSONDecoderFactory(r io.Reader, _ map[string]string) Decoder {
+	return json.NewDecoder(r)
 }
 
-func NestedJSONDecoderFactory(map[string]string) DecoderFactory {
-	return func(r io.Reader) Decoder {
-		dec := json.NewDecoder(r)
-		tok, err := dec.Token()
-		for err == nil {
-			if v, ok := tok.(json.Delim); ok {
-				if v == '[' {
-					break
-				}
+func NestedJSONDecoderFactory(r io.Reader, _ map[string]string) Decoder {
+	dec := json.NewDecoder(r)
+	tok, err := dec.Token()
+	for err == nil {
+		if v, ok := tok.(json.Delim); ok {
+			if v == '[' {
+				break
 			}
-			tok, err = dec.Token()
 		}
-		if err != nil {
-			return &errorDecoder{fmt.Errorf("unexpected token: %w", err)}
-		}
-		return dec
+		tok, err = dec.Token()
 	}
+	if err != nil {
+		return &errorDecoder{fmt.Errorf("unexpected token: %w", err)}
+	}
+	return dec
 }

--- a/handler/forwarder/s3http/internal/decoders/text.go
+++ b/handler/forwarder/s3http/internal/decoders/text.go
@@ -9,11 +9,9 @@ import (
 	"strconv"
 )
 
-func TextDecoderFactory(map[string]string) DecoderFactory {
-	return func(r io.Reader) Decoder {
-		return &TextDecoder{
-			Reader: bufio.NewReader(r),
-		}
+func TextDecoderFactory(r io.Reader, _ map[string]string) Decoder {
+	return &TextDecoder{
+		Reader: bufio.NewReader(r),
 	}
 }
 

--- a/handler/forwarder/s3http/internal/decoders/wrapper.go
+++ b/handler/forwarder/s3http/internal/decoders/wrapper.go
@@ -16,12 +16,12 @@ var wrappers = map[string]Wrapper{
 type Wrapper func(DecoderFactory) DecoderFactory
 
 func GzipWrapper(fn DecoderFactory) DecoderFactory {
-	return func(r io.Reader) Decoder {
+	return func(r io.Reader, params map[string]string) Decoder {
 		gr, err := gzip.NewReader(r)
 		if err != nil {
 			return &errorDecoder{fmt.Errorf("failed to read gzip: %w", err)}
 		}
 		defer gr.Close()
-		return fn(gr)
+		return fn(gr, params)
 	}
 }


### PR DESCRIPTION
Simplify DecoderFactory by allowing caller to pass in parameters alongside io.Reader.