### PR TITLE
fix(forwarder): reduce error wrapping

### DIFF
--- a/handler/forwarder/s3http/internal/batch/queue.go
+++ b/handler/forwarder/s3http/internal/batch/queue.go
@@ -82,7 +82,7 @@ func (q *Queue) Process(ctx context.Context, c Handler) error {
 	for {
 		select {
 		case <-ctx.Done():
-			return fmt.Errorf("cancelled consume: %w", ctx.Err())
+			return fmt.Errorf("cancelled process: %w", ctx.Err())
 		case buf, ok := <-q.ch:
 			if !ok {
 				return nil
@@ -90,7 +90,8 @@ func (q *Queue) Process(ctx context.Context, c Handler) error {
 			err := c.Handle(ctx, buf)
 			bufPool.Put(buf)
 			if err != nil {
-				return fmt.Errorf("failed to consume: %w", err)
+				// nolint:wrapcheck
+				return err
 			}
 		}
 	}

--- a/handler/forwarder/s3http/internal/batch/runner.go
+++ b/handler/forwarder/s3http/internal/batch/runner.go
@@ -102,8 +102,6 @@ func Run(ctx context.Context, r *RunInput) error {
 		return nil
 	})
 
-	if err := g.Wait(); err != nil {
-		return fmt.Errorf("failed to stream data: %w", err)
-	}
-	return nil
+	// nolint:wrapcheck
+	return g.Wait()
 }

--- a/handler/forwarder/s3http/internal/request/builder.go
+++ b/handler/forwarder/s3http/internal/request/builder.go
@@ -10,7 +10,7 @@ import (
 var (
 	ErrNoConfig   = errors.New("missing config")
 	ErrMissingURL = errors.New("missing URL")
-	ErrStatus     = errors.New("failed to upload: %w")
+	ErrStatus     = errors.New("failed to upload")
 )
 
 type Doer interface {


### PR DESCRIPTION
This commit reduces the amount of spam in error messages derived from HTTP request failures. Prior to this commit, a 401 would surface as:

```
failed to write messages: failed to process: failed to stream data: failed to consume: failed to upload: %w: unauthorized
```

The `%w` is a bug, while the excessive length can be handled by ditching error wrapping in some of the chain.