### PR TITLE
fix(forwarder): ignore empty files on HTTP forwarding

### DIFF
--- a/handler/forwarder/s3http/client.go
+++ b/handler/forwarder/s3http/client.go
@@ -110,6 +110,12 @@ func (c *Client) CopyObject(ctx context.Context, params *s3.CopyObjectInput, opt
 		return nil, fmt.Errorf("failed to get object: %w", err)
 	}
 	defer getResp.Body.Close()
+
+	if getResp.ContentLength != nil && *getResp.ContentLength == 0 {
+		logger.V(6).Info("skipping empty file")
+		return toCopyOutput(nil), nil
+	}
+
 	putResp, err := c.PutObject(ctx, toPutInput(params, getResp), opts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to put object: %w", err)


### PR DESCRIPTION
We want to ignore empty files when submitting over HTTP, since they would produce no records even if the decoder supported an immediate EOF. Due to a limitation in the AWS SDK, we cannot disambiguate whether a file size is absent or 0 when processing an S3 bucket notification. Instead, we inspect the ContentLength of the S3 GetObject response.

This handling is not needed in the Filedrop case, since we handle empty files in the ingest pipeline, and we only execute a single CopyObject command.