### PR TITLE
feat(logwriter): support log group exclusion

### DIFF
--- a/apps/logwriter/template.yaml
+++ b/apps/logwriter/template.yaml
@@ -59,9 +59,10 @@ Parameters:
     Type: CommaDelimitedList
     Description: >-
       Comma separated list of patterns.
-      We will only subscribe to log groups that have names matching one of the
-      provided strings based on strings based on a case-sensitive substring
-      search. To subscribe to all log groups, use the wildcard operator *.
+      We will only subscribe to log groups that have names matching any of the
+      provided strings based on a case-sensitive substring search. See the AWS
+      `DescribeLogGroups` action for more information.
+      To subscribe to all log groups, use the wildcard operator *.
     Default: ''
   LogGroupNamePrefixes:
     Type: CommaDelimitedList
@@ -69,6 +70,12 @@ Parameters:
       Comma separated list of prefixes. The lambda function will only apply to
       log groups that start with a provided string. To subscribe to all log
       groups, use the wildcard operator *.
+    Default: ''
+  ExcludeLogGroupNamePatterns:
+    Type: CommaDelimitedList
+    Description: >-
+      Comma separated list of patterns. This paramter is used to filter out log
+      groups from subscription, and supports the use of regular expressions.
     Default: ''
   DiscoveryRate:
     Type: String
@@ -453,6 +460,9 @@ Resources:
           LOG_GROUP_NAME_PATTERNS: !Join
             - ','
             - !Ref LogGroupNamePatterns
+          EXCLUDE_LOG_GROUP_NAME_PATTERNS: !Join
+            - ','
+            - !Ref ExcludeLogGroupNamePatterns
           ROLE_ARN: !GetAtt DestinationRole.Arn
           QUEUE_URL: !Ref Queue
           VERBOSITY: !If

--- a/apps/stack/template.yaml
+++ b/apps/stack/template.yaml
@@ -32,6 +32,7 @@ Metadata:
         Parameters:
           - LogGroupNamePatterns
           - LogGroupNamePrefixes
+          - ExcludeLogGroupNamePatterns
       - Label:
           default: CloudWatch Metrics
         Parameters:
@@ -93,6 +94,12 @@ Parameters:
     Description: >-
       Comma separated list of prefixes. If not empty, the lambda function will
       only apply to log groups that start with a provided string.
+    Default: ''
+  ExcludeLogGroupNamePatterns:
+    Type: CommaDelimitedList
+    Description: >-
+      Comma separated list of patterns. This paramter is used to filter out log
+      groups from subscription, and supports the use of regular expressions.
     Default: ''
   MetricStreamFilterUri:
     Type: String
@@ -282,6 +289,9 @@ Resources:
         DebugEndpoint: !Ref DebugEndpoint
         LogGroupNamePrefixes: !Join [",", !Ref LogGroupNamePrefixes]
         LogGroupNamePatterns: !Join [",", !Ref LogGroupNamePatterns]
+        ExcludeLogGroupNamePatterns: !Join
+          - ","
+          - !Ref ExcludeLogGroupNamePatterns
         FilterName: 'observe-logs-subscription'
         DiscoveryRate: "24 hours"
         NameOverride: !If

--- a/cmd/subscriber/main.go
+++ b/cmd/subscriber/main.go
@@ -23,15 +23,16 @@ const (
 )
 
 var env struct {
-	FilterName           string   `env:"FILTER_NAME"`
-	FilterPattern        string   `env:"FILTER_PATTERN"`
-	DestinationARN       string   `env:"DESTINATION_ARN"`
-	RoleARN              *string  `env:"ROLE_ARN,noinit"` // noinit retains nil if env var unset
-	LogGroupNamePatterns []string `env:"LOG_GROUP_NAME_PATTERNS"`
-	LogGroupNamePrefixes []string `env:"LOG_GROUP_NAME_PREFIXES"`
-	QueueURL             string   `env:"QUEUE_URL,required"`
-	Verbosity            int      `env:"VERBOSITY,default=1"`
-	ServiceName          string   `env:"OTEL_SERVICE_NAME,default=subscriber"`
+	FilterName                  string   `env:"FILTER_NAME"`
+	FilterPattern               string   `env:"FILTER_PATTERN"`
+	DestinationARN              string   `env:"DESTINATION_ARN"`
+	RoleARN                     *string  `env:"ROLE_ARN,noinit"` // noinit retains nil if env var unset
+	LogGroupNamePatterns        []string `env:"LOG_GROUP_NAME_PATTERNS"`
+	LogGroupNamePrefixes        []string `env:"LOG_GROUP_NAME_PREFIXES"`
+	ExcludeLogGroupNamePatterns []string `env:"EXCLUDE_LOG_GROUP_NAME_PATTERNS"`
+	QueueURL                    string   `env:"QUEUE_URL,required"`
+	Verbosity                   int      `env:"VERBOSITY,default=1"`
+	ServiceName                 string   `env:"OTEL_SERVICE_NAME,default=subscriber"`
 
 	AWSMaxAttempts string `env:"AWS_MAX_ATTEMPTS,default=7"`
 	AWSRetryMode   string `env:"AWS_RETRY_MODE,default=adaptive"`
@@ -105,14 +106,15 @@ func realInit() error {
 	iq := subscriber.InstrumentQueue(*queue)
 
 	s, err := subscriber.New(&subscriber.Config{
-		FilterName:           env.FilterName,
-		FilterPattern:        env.FilterPattern,
-		DestinationARN:       env.DestinationARN,
-		RoleARN:              env.RoleARN,
-		LogGroupNamePrefixes: env.LogGroupNamePrefixes,
-		LogGroupNamePatterns: env.LogGroupNamePatterns,
-		CloudWatchLogsClient: cloudwatchlogs.NewFromConfig(awsCfg),
-		Queue:                &iq,
+		FilterName:                  env.FilterName,
+		FilterPattern:               env.FilterPattern,
+		DestinationARN:              env.DestinationARN,
+		RoleARN:                     env.RoleARN,
+		LogGroupNamePrefixes:        env.LogGroupNamePrefixes,
+		LogGroupNamePatterns:        env.LogGroupNamePatterns,
+		ExcludeLogGroupNamePatterns: env.ExcludeLogGroupNamePatterns,
+		CloudWatchLogsClient:        cloudwatchlogs.NewFromConfig(awsCfg),
+		Queue:                       &iq,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create handler: %w", err)

--- a/docs/logwriter.md
+++ b/docs/logwriter.md
@@ -12,6 +12,7 @@ Additionally, the stack is capable of subscribing log groups and provides a meth
 | `Prefix` | String | Optional prefix to write log records to. |
 | `LogGroupNamePatterns` | CommaDelimitedList | Comma separated list of patterns. We will only subscribe to log groups that have names matching one of the provided strings based on strings based on a case-sensitive substring search. To subscribe to all log groups, use the wildcard operator *. |
 | `LogGroupNamePrefixes` | CommaDelimitedList | Comma separated list of prefixes. The lambda function will only apply to log groups that start with a provided string. To subscribe to all log groups, use the wildcard operator *. |
+| `ExcludeLogGroupNamePatterns` | CommaDelimitedList | Comma separated list of patterns. This paramter is used to filter out log groups from subscription, and supports the use of regular expressions. |
 | `DiscoveryRate` | String | EventBridge rate expression for periodically triggering discovery. If not set, no eventbridge rules are configured. |
 | `FilterName` | String | Subscription filter name. Existing filters that have this name as a prefix will be removed. |
 | `FilterPattern` | String | Subscription filter pattern. |

--- a/docs/stack.md
+++ b/docs/stack.md
@@ -31,6 +31,7 @@ The Observe stack provisions the following components:
 | `ExcludeResourceTypes` | CommaDelimitedList | Exclude a subset of resource types from configuration collection. This parameter can only be set if IncludeResourceTypes is wildcarded. |
 | `LogGroupNamePatterns` | CommaDelimitedList | Comma separated list of patterns. If not empty, the lambda function will only apply to log groups that have names that match one of the provided strings based on a case-sensitive substring search. |
 | `LogGroupNamePrefixes` | CommaDelimitedList | Comma separated list of prefixes. If not empty, the lambda function will only apply to log groups that start with a provided string. |
+| `ExcludeLogGroupNamePatterns` | CommaDelimitedList | Comma separated list of patterns. This paramter is used to filter out log groups from subscription, and supports the use of regular expressions. |
 | `MetricStreamFilterUri` | String | S3 URI containing filters for metrics to be collected by CloudWatch Metrics Stream. If empty, no metrics will be collected. |
 | `SourceBucketNames` | CommaDelimitedList | A list of bucket names which the forwarder is allowed to read from. |
 | `ContentTypeOverrides` | CommaDelimitedList | A list of key value pairs. The key is a regular expression which is applied to the S3 source (<bucket>/<key>) of forwarded files. The value is the content type to set for matching files. For example, `\.json$=application/x-ndjson` would forward all files ending in `.json` as newline delimited JSON files. |

--- a/handler/subscriber/config_test.go
+++ b/handler/subscriber/config_test.go
@@ -67,7 +67,6 @@ func TestConfig(t *testing.T) {
 			},
 			ExpectError: subscriber.ErrInvalidLogGroupName,
 		},
-
 		{
 			Config: subscriber.Config{
 				CloudWatchLogsClient: &handlertest.CloudWatchLogsClient{},
@@ -75,6 +74,14 @@ func TestConfig(t *testing.T) {
 				LogGroupNamePrefixes: []string{"\\"},
 			},
 			ExpectError: subscriber.ErrInvalidLogGroupName,
+		},
+		{
+			Config: subscriber.Config{
+				CloudWatchLogsClient:        &handlertest.CloudWatchLogsClient{},
+				FilterName:                  "observe-logs-subscription",
+				ExcludeLogGroupNamePatterns: []string{"\\"},
+			},
+			ExpectError: subscriber.ErrInvalidRegexp,
 		},
 		{
 			Config: subscriber.Config{
@@ -136,6 +143,19 @@ func TestLogFilter(t *testing.T) {
 				"prod-1":  true,
 				"eu-prod": true,
 				"staging": true,
+			},
+		},
+		{
+			Config: subscriber.Config{
+				LogGroupNamePatterns:        []string{"*"},
+				ExcludeLogGroupNamePatterns: []string{"-prod", "gin$"},
+				DestinationARN:              "hello",
+			},
+			Matches: map[string]bool{
+				"prod-1":  true,
+				"eu-prod": false,
+				"staging": true,
+				"stagin":  false,
 			},
 		},
 	}


### PR DESCRIPTION
Add support for excluding log groups. Up until now we have adhered strictly to the options supported by the DescribeLogGroups API. There is no means of excluding log groups from the API response, so we implement filtering support in the client side instead. This allows us a bit more flexibility, and we can introduce regular expression support for exclusion.