### PR TITLE
fix(stack): match expiration values

### DIFF
--- a/apps/forwarder/template.yaml
+++ b/apps/forwarder/template.yaml
@@ -188,7 +188,7 @@ Resources:
         - !Ref AWS::StackName
         - !Ref NameOverride
       DelaySeconds: 0
-      MessageRetentionPeriod: 1209600
+      MessageRetentionPeriod: 345600
       RedrivePolicy:
         deadLetterTargetArn: !GetAtt DeadLetter.Arn
         maxReceiveCount: 4

--- a/apps/stack/template.yaml
+++ b/apps/stack/template.yaml
@@ -211,7 +211,7 @@ Resources:
     Properties:
       LifecycleConfiguration:
         Rules:
-          - ExpirationInDays: 1
+          - ExpirationInDays: 4
             Status: Enabled
       NotificationConfiguration:
         TopicConfigurations:


### PR DESCRIPTION
Adjust SQS retention and S3 expiration duration to match 4 days by default.

Previously, SQS retention exceeded S3 expiration, which would potentially mean that any "copy" message would fail once eventually retried.