### PR TITLE
ci: improve release robustness

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -144,24 +144,11 @@ jobs:
     - name: AWS Info
       run: aws sts get-caller-identity
 
-    - name: aws sam release (versioned)
+    - name: aws sam release
       run: make release-all
       env:
+        TAG: fromJSON('{"workflow_dispatch": "latest", "push": "beta"}')[github.event_name]
         VERSION: ${{ needs.github-release.outputs.VERSION }}
-        AWS_REGION: ${{ matrix.region }}
-
-    - name: aws sam release (beta)
-      if: github.event_name == 'push'
-      run: make release-all
-      env:
-        VERSION: beta
-        AWS_REGION: ${{ matrix.region }}
-
-    - name: aws sam release (stable)
-      if: github.event_name == 'workflow_dispatch'
-      run: make release-all
-      env:
-        VERSION: latest
         AWS_REGION: ${{ matrix.region }}
 
     - name: delete pre-releases


### PR DESCRIPTION
This commit reorders operations in order to reduce the scope for error in case of a CI failure.

We run the release job concurrently for each region. If any job fails, all other jobs are interrupted. This opened the possibility for the root `packaged.yaml` template to be uploaded, but with incorrect ACLs.

We should always copy the template with the ACL directive. This eliminates the possibility of the object existing with the incorrect permissions. Furthermore, we should only upload the template once all objects it refers to are also publicly readable. That way we ensure that if the template is accessible, it is also installable.