### PR TITLE
fix: set root span to server kind

### DIFF
--- a/cmd/forwarder/main.go
+++ b/cmd/forwarder/main.go
@@ -83,7 +83,7 @@ func realInit() (err error) {
 		trace.WithInstrumentationVersion(version.Version),
 	)
 
-	ctx, span := tracer.Start(ctx, "realInit")
+	ctx, span := tracer.Start(ctx, "realInit", trace.WithSpanKind(trace.SpanKindServer))
 	defer func() {
 		if err != nil {
 			span.RecordError(err)

--- a/cmd/loggroupgenerator/main.go
+++ b/cmd/loggroupgenerator/main.go
@@ -177,7 +177,7 @@ func main() {
 		}
 	}()
 
-	ctx, span := tracer.Start(context.Background(), "invocation")
+	ctx, span := tracer.Start(context.Background(), "invocation", trace.WithSpanKind(trace.SpanKindServer))
 	defer span.End()
 
 	if err := realMain(ctx); err != nil {

--- a/cmd/subscriber/main.go
+++ b/cmd/subscriber/main.go
@@ -84,7 +84,7 @@ func realInit() error {
 		trace.WithInstrumentationVersion(version.Version),
 	)
 
-	ctx, span := tracer.Start(ctx, "realInit")
+	ctx, span := tracer.Start(ctx, "realInit", trace.WithSpanKind(trace.SpanKindServer))
 	defer func() {
 		if err != nil {
 			span.RecordError(err)


### PR DESCRIPTION
Marking the root span as a service entry point makes browsing traces in UI easier.