### PR TITLE
fix(forwarder): relax IAM role naming

### DIFF
--- a/apps/forwarder/template.yaml
+++ b/apps/forwarder/template.yaml
@@ -260,9 +260,12 @@ Resources:
     Type: 'AWS::IAM::Role'
     Properties:
       RoleName: !If
-        - UseStackName
-        - !Ref AWS::StackName
-        - !Ref NameOverride
+        - NoDataAccessPointArn
+        - !Ref AWS::NoValue
+        - !If
+          - UseStackName
+          - !Ref AWS::StackName
+          - !Ref NameOverride
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:


### PR DESCRIPTION
The IAM role of the forwarder only needs to be known when forwarding data to Filedrop. For cases where we are not pointing at an S3 data access point, we can fallback to letting Cloudformation generating a unique role name. Doing so avoids the possibility of name clashes when installing a forwarder in different regions.