### PR TITLE
fix: set server span kind on invoke

### DIFF
--- a/tracing/mux.go
+++ b/tracing/mux.go
@@ -15,9 +15,10 @@ type LambdaHandler struct {
 }
 
 func (h *LambdaHandler) Invoke(ctx context.Context, payload []byte) (response []byte, err error) {
-	cctx, span := h.Tracer.Start(ctx, "Invoke", trace.WithAttributes(
-		attribute.String("payload", string(payload)),
-	))
+	cctx, span := h.Tracer.Start(ctx, "Invoke",
+		trace.WithAttributes(attribute.String("payload", string(payload))),
+		trace.WithSpanKind(trace.SpanKindServer),
+	)
 	defer func() {
 		if err != nil {
 			span.RecordError(err)


### PR DESCRIPTION
We currently only handle lambda initialization as a server kind span. Intercept the lambda invocation and set as server kind too.