### PR TITLE
fix: introduce otellambda instrumentation

### DIFF
--- a/cmd/forwarder/main.go
+++ b/cmd/forwarder/main.go
@@ -161,10 +161,7 @@ func realInit() (err error) {
 		return fmt.Errorf("failed to register functions: %w", err)
 	}
 
-	entrypoint = &tracing.LambdaHandler{
-		Handler: mux,
-		Tracer:  tracer,
-	}
+	entrypoint = tracing.NewLambdaHandler(mux, tracerProvider)
 	return nil
 }
 

--- a/cmd/subscriber/main.go
+++ b/cmd/subscriber/main.go
@@ -133,10 +133,7 @@ func realInit() error {
 		return fmt.Errorf("failed to register functions: %w", err)
 	}
 
-	entrypoint = &tracing.LambdaHandler{
-		Handler: mux,
-		Tracer:  tracer,
-	}
+	entrypoint = tracing.NewLambdaHandler(mux, tracerProvider)
 	return nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -61,6 +61,7 @@ require (
 	github.com/prometheus/common v0.53.0 // indirect
 	github.com/prometheus/procfs v0.15.0 // indirect
 	go.opentelemetry.io/contrib/bridges/prometheus v0.52.0 // indirect
+	go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-lambda-go/otellambda v0.52.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.27.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.27.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.27.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -123,6 +123,8 @@ go.opentelemetry.io/contrib/detectors/aws/lambda v0.52.0 h1:aZAZUtzXd7dklbWDqf0s
 go.opentelemetry.io/contrib/detectors/aws/lambda v0.52.0/go.mod h1:0oIsMo4DjOJNB/mn/bssl3ba7TEZhSgqe26vRMoxHv4=
 go.opentelemetry.io/contrib/exporters/autoexport v0.52.0 h1:G/AGl5O78ZKHs63Rl65P1HyZfDnTyxjv8r7dbdZ9fB0=
 go.opentelemetry.io/contrib/exporters/autoexport v0.52.0/go.mod h1:WoVWPZjJ7EB5Z9aROW1DZuRIoFEemxmhCdZJlcjY2AE=
+go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-lambda-go/otellambda v0.52.0 h1:djhGC0347ZyXb4HB7qqVoNRlyEmRshXl2lzD2cU4fSI=
+go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-lambda-go/otellambda v0.52.0/go.mod h1:+PgU2bOkTOL1XcmdCe/8EA5H5XY/RRq2QqQRyjP5RZ0=
 go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws v0.52.0 h1:kAytSRJYoIy4eJtDOfSGf9LOCD4QdXFN37YJs0+bYrw=
 go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws v0.52.0/go.mod h1:l6VnFEqDdeMSMfwULTDDY9ewlnlVLhmvBainVT+h/Zs=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.52.0 h1:9l89oX4ba9kHbBol3Xin3leYJ+252h0zszDtBwyKe2A=

--- a/vendor/go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-lambda-go/otellambda/LICENSE
+++ b/vendor/go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-lambda-go/otellambda/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-lambda-go/otellambda/README.md
+++ b/vendor/go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-lambda-go/otellambda/README.md
@@ -1,0 +1,117 @@
+# OpenTelemetry AWS Lambda Instrumentation for Golang
+
+[![Go Reference][goref-image]][goref-url]
+[![Apache License][license-image]][license-url]
+
+This module provides instrumentation for [`AWS Lambda`](https://docs.aws.amazon.com/lambda/latest/dg/golang-handler.html).
+
+## Installation
+
+```bash
+go get -u go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-lambda-go/otellambda
+```
+
+## example
+See [./example](https://github.com/open-telemetry/opentelemetry-go-contrib/tree/main/instrumentation/github.com/aws/aws-lambda-go/otellambda/example)
+
+## Usage
+
+Create a sample Lambda Go application such as below.
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"github.com/aws/aws-lambda-go/lambda"
+)
+
+type MyEvent struct {
+	Name string `json:"name"`
+}
+
+func HandleRequest(ctx context.Context, name MyEvent) (string, error) {
+	return fmt.Sprintf("Hello %s!", name.Name ), nil
+}
+
+func main() {
+	lambda.Start(HandleRequest)
+}
+```
+
+Now use the provided wrapper to instrument your basic Lambda function:
+```go
+// Add import
+import "go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-lambda-go/otellambda"
+
+// wrap lambda handler function
+func main() {
+	lambda.Start(otellambda.InstrumentHandler(HandleRequest))
+}
+```
+
+## AWS Lambda Instrumentation Options
+
+| Options | Input Type  | Description | Default |
+| --- | --- | --- | --- |
+| `WithTracerProvider` | `trace.TracerProvider` | Provide a custom `TracerProvider` for creating spans. Consider using the [AWS Lambda Resource Detector][lambda-detector-url] with your tracer provider to improve tracing information. | `otel.GetTracerProvider()`
+| `WithFlusher` | `otellambda.Flusher`  | This instrumentation will call the `ForceFlush` method of its `Flusher` at the end of each invocation. Should you be using asynchronous logic (such as `sddktrace's BatchSpanProcessor`) it is very import for spans to be `ForceFlush`'ed before [Lambda freezes](https://docs.aws.amazon.com/lambda/latest/dg/runtimes-context.html) to avoid data delays. | `Flusher` with noop `ForceFlush`
+| `WithEventToCarrier` | `func(eventJSON []byte) propagation.TextMapCarrier{}` | Function for providing custom logic to support retrieving trace header from different event types that are handled by AWS Lambda (e.g., SQS, CloudWatch, Kinesis, API Gateway) and returning them in a `propagation.TextMapCarrier` which a Propagator can use to extract the trace header into the context. | Function which returns an empty `TextMapCarrier` - new spans will be part of a new Trace and have no parent past Lambda instrumentation span
+| `WithPropagator` | `propagation.Propagator` | The `Propagator` the instrumentation will use to extract trace information into the context. | `otel.GetTextMapPropagator()` |
+
+### Usage With Options Example
+
+```go
+var someHeaderKey = "Key" // used by propagator and EventToCarrier function to identify trace header
+
+type mockHTTPRequest struct {
+	Headers map[string][]string
+	Body string
+}
+
+func mockEventToCarrier(eventJSON []byte) propagation.TextMapCarrier{
+	var request mockHTTPRequest
+	_ = json.unmarshal(eventJSON, &request)
+	return propogation.HeaderCarrier{someHeaderKey: []string{request.Headers[someHeaderKey]}}
+}
+
+type mockPropagator struct{}
+// Extract - read from `someHeaderKey`
+// Inject
+// Fields
+
+func HandleRequest(ctx context.Context, request mockHTTPRequest) error {
+	return fmt.Sprintf("Hello %s!", request.Body ), nil
+}
+
+func main() {
+	exp, _ := stdouttrace.New()
+    
+	tp := sdktrace.NewTracerProvider(
+		    sdktrace.WithBatcher(exp))
+	
+	lambda.Start(otellambda.InstrumentHandler(HandleRequest,
+		                                    otellambda.WithTracerProvider(tp),
+		                                    otellambda.WithFlusher(tp),
+		                                    otellambda.WithEventToCarrier(mockEventToCarrier),
+		                                    otellambda.WithPropagator(mockPropagator{})))
+}
+```
+
+## Useful links
+
+- For more information on OpenTelemetry, visit: <https://opentelemetry.io/>
+- For more about OpenTelemetry Go: <https://github.com/open-telemetry/opentelemetry-go>
+- For help or feedback on this project, join us in [GitHub Discussions][discussions-url] 
+
+## License
+
+Apache 2.0 - See [LICENSE][license-url] for more information.
+
+[license-url]: https://github.com/open-telemetry/opentelemetry-go-contrib/blob/main/LICENSE
+[license-image]: https://img.shields.io/badge/license-Apache_2.0-green.svg?style=flat
+[goref-image]: https://pkg.go.dev/badge/go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-lambda-go/otellambda.svg
+[goref-url]: https://pkg.go.dev/go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-lambda-go/otellambda
+[discussions-url]: https://github.com/open-telemetry/opentelemetry-go/discussions
+[lambda-detector-url]: https://github.com/open-telemetry/opentelemetry-go-contrib/blob/main/detectors/aws/lambda

--- a/vendor/go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-lambda-go/otellambda/config.go
+++ b/vendor/go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-lambda-go/otellambda/config.go
@@ -1,0 +1,116 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package otellambda // import "go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-lambda-go/otellambda"
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// A Flusher dictates how the instrumentation will attempt to flush
+// unexported spans at the end of each Lambda innovation. This is
+// very important in asynchronous settings because the Lambda runtime
+// may enter a 'frozen' state any time after the invocation completes.
+// Should this freeze happen and spans are left unexported, there can be a
+// long delay before those spans are exported.
+type Flusher interface {
+	ForceFlush(context.Context) error
+}
+
+type noopFlusher struct{}
+
+func (*noopFlusher) ForceFlush(context.Context) error { return nil }
+
+// Compile time check our noopFlusher implements Flusher.
+var _ Flusher = &noopFlusher{}
+
+// An EventToCarrier function defines how the instrumentation should
+// prepare a TextMapCarrier for the configured propagator to read from. This
+// extra step is necessary because Lambda does not have HTTP headers to read
+// from and instead stores the headers it was invoked with (including TraceID, etc.)
+// as part of the invocation event. If using the AWS XRay tracing then the
+// trace information is instead stored in the Lambda environment.
+type EventToCarrier func(eventJSON []byte) propagation.TextMapCarrier
+
+func emptyEventToCarrier([]byte) propagation.TextMapCarrier {
+	return propagation.HeaderCarrier{}
+}
+
+// Compile time check our emptyEventToCarrier implements EventToCarrier.
+var _ EventToCarrier = emptyEventToCarrier
+
+// Option applies a configuration option.
+type Option interface {
+	apply(*config)
+}
+
+type optionFunc func(*config)
+
+func (o optionFunc) apply(c *config) {
+	o(c)
+}
+
+type config struct {
+	// TracerProvider is the TracerProvider which will be used
+	// to create instrumentation spans
+	// The default value of TracerProvider the global otel TracerProvider
+	// returned by otel.GetTracerProvider()
+	TracerProvider trace.TracerProvider
+
+	// Flusher is the mechanism used to flush any unexported spans
+	// each Lambda Invocation to avoid spans being unexported for long
+	// when periods of time if Lambda freezes the execution environment
+	// The default value of Flusher is a noop Flusher, using this
+	// default can result in long data delays in asynchronous settings
+	Flusher Flusher
+
+	// EventToCarrier is the mechanism used to retrieve the TraceID
+	// from the event or environment and generate a TextMapCarrier which
+	// can then be used by a Propagator to extract the TraceID into our context
+	// The default value of eventToCarrier is emptyEventToCarrier which returns
+	// an empty HeaderCarrier, using this default will cause new spans to be part
+	// of a new Trace and have no parent past our Lambda instrumentation span
+	EventToCarrier EventToCarrier
+
+	// Propagator is the Propagator which will be used
+	// to extract Trace info into the context
+	// The default value of Propagator the global otel Propagator
+	// returned by otel.GetTextMapPropagator()
+	Propagator propagation.TextMapPropagator
+}
+
+// WithTracerProvider configures the TracerProvider used by the
+// instrumentation.
+//
+// By default, the global TracerProvider is used.
+func WithTracerProvider(tracerProvider trace.TracerProvider) Option {
+	return optionFunc(func(c *config) {
+		c.TracerProvider = tracerProvider
+	})
+}
+
+// WithFlusher sets the used flusher.
+func WithFlusher(flusher Flusher) Option {
+	return optionFunc(func(c *config) {
+		c.Flusher = flusher
+	})
+}
+
+// WithEventToCarrier sets the used EventToCarrier.
+func WithEventToCarrier(eventToCarrier EventToCarrier) Option {
+	return optionFunc(func(c *config) {
+		c.EventToCarrier = eventToCarrier
+	})
+}
+
+// WithPropagator configures the propagator used by the instrumentation.
+//
+// By default, the global TextMapPropagator will be used.
+func WithPropagator(propagator propagation.TextMapPropagator) Option {
+	return optionFunc(func(c *config) {
+		c.Propagator = propagator
+	})
+}

--- a/vendor/go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-lambda-go/otellambda/doc.go
+++ b/vendor/go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-lambda-go/otellambda/doc.go
@@ -1,0 +1,11 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package otellambda instruments the github.com/aws/aws-lambda-go package.
+//
+// Two wrappers are provided which can be used to instrument Lambda,
+// one for each Lambda entrypoint. Their usages are shown below.
+//
+// lambda.Start(<user function>) entrypoint: lambda.Start(otellambda.InstrumentHandler(<user function>))
+// lambda.StartHandler(<user Handler>) entrypoint: lambda.StartHandler(otellambda.WrapHandler(<user Handler>))
+package otellambda // import "go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-lambda-go/otellambda"

--- a/vendor/go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-lambda-go/otellambda/lambda.go
+++ b/vendor/go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-lambda-go/otellambda/lambda.go
@@ -1,0 +1,98 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package otellambda // import "go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-lambda-go/otellambda"
+
+import (
+	"context"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/aws/aws-lambda-go/lambdacontext"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
+	"go.opentelemetry.io/otel/trace"
+)
+
+const (
+	// ScopeName is the instrumentation scope name.
+	ScopeName = "go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-lambda-go/otellambda"
+)
+
+var errorLogger = log.New(log.Writer(), "OTel Lambda Error: ", 0)
+
+type instrumentor struct {
+	configuration config
+	resAttrs      []attribute.KeyValue
+	tracer        trace.Tracer
+}
+
+func newInstrumentor(opts ...Option) instrumentor {
+	cfg := config{
+		TracerProvider: otel.GetTracerProvider(),
+		Flusher:        &noopFlusher{},
+		EventToCarrier: emptyEventToCarrier,
+		Propagator:     otel.GetTextMapPropagator(),
+	}
+	for _, opt := range opts {
+		opt.apply(&cfg)
+	}
+
+	return instrumentor{
+		configuration: cfg,
+		tracer:        cfg.TracerProvider.Tracer(ScopeName, trace.WithInstrumentationVersion(Version())),
+		resAttrs:      []attribute.KeyValue{},
+	}
+}
+
+// Logic to start OTel Tracing.
+func (i *instrumentor) tracingBegin(ctx context.Context, eventJSON []byte) (context.Context, trace.Span) {
+	// Add trace id to context
+	mc := i.configuration.EventToCarrier(eventJSON)
+	ctx = i.configuration.Propagator.Extract(ctx, mc)
+
+	var span trace.Span
+	spanName := os.Getenv("AWS_LAMBDA_FUNCTION_NAME")
+
+	var attributes []attribute.KeyValue
+	lc, ok := lambdacontext.FromContext(ctx)
+	if !ok {
+		errorLogger.Println("failed to load lambda context from context, ensure tracing enabled in Lambda")
+	}
+	if lc != nil {
+		ctxRequestID := lc.AwsRequestID
+		attributes = append(attributes, semconv.FaaSInvocationID(ctxRequestID))
+
+		// Some resource attrs added as span attrs because lambda
+		// resource detectors are created before a lambda
+		// invocation and therefore lack lambdacontext.
+		// Create these attrs upon first invocation
+		if len(i.resAttrs) == 0 {
+			ctxFunctionArn := lc.InvokedFunctionArn
+			attributes = append(attributes, semconv.AWSLambdaInvokedARN(ctxFunctionArn))
+			arnParts := strings.Split(ctxFunctionArn, ":")
+			if len(arnParts) >= 5 {
+				attributes = append(attributes, semconv.CloudAccountID(arnParts[4]))
+			}
+		}
+		attributes = append(attributes, i.resAttrs...)
+	}
+
+	ctx, span = i.tracer.Start(ctx, spanName, trace.WithSpanKind(trace.SpanKindServer), trace.WithAttributes(attributes...))
+
+	return ctx, span
+}
+
+// Logic to wrap up OTel Tracing.
+func (i *instrumentor) tracingEnd(ctx context.Context, span trace.Span) {
+	span.End()
+
+	// force flush any tracing data since lambda may freeze
+	err := i.configuration.Flusher.ForceFlush(ctx)
+	if err != nil {
+		errorLogger.Println("failed to force a flush, lambda may freeze before instrumentation exported: ", err)
+	}
+}

--- a/vendor/go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-lambda-go/otellambda/version.go
+++ b/vendor/go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-lambda-go/otellambda/version.go
@@ -1,0 +1,17 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package otellambda // import "go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-lambda-go/otellambda"
+
+// Version is the current release version of the AWS Lambda instrumentation.
+func Version() string {
+	return "0.52.0"
+	// This string is updated by the pre_release.sh script during release
+}
+
+// SemVersion is the semantic version to be supplied to tracer/meter creation.
+//
+// Deprecated: Use [Version] instead.
+func SemVersion() string {
+	return Version()
+}

--- a/vendor/go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-lambda-go/otellambda/wrapHandler.go
+++ b/vendor/go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-lambda-go/otellambda/wrapHandler.go
@@ -1,0 +1,39 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package otellambda // import "go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-lambda-go/otellambda"
+
+import (
+	"context"
+
+	"github.com/aws/aws-lambda-go/lambda"
+)
+
+// wrappedHandler is a struct which holds an instrumentor
+// as well as the user's original lambda.Handler and is
+// able to instrument invocations of the user's lambda.Handler.
+type wrappedHandler struct {
+	instrumentor instrumentor
+	handler      lambda.Handler
+}
+
+// Compile time check our Handler implements lambda.Handler.
+var _ lambda.Handler = wrappedHandler{}
+
+// Invoke adds OTel span surrounding customer Handler invocation.
+func (h wrappedHandler) Invoke(ctx context.Context, payload []byte) ([]byte, error) {
+	ctx, span := h.instrumentor.tracingBegin(ctx, payload)
+	defer h.instrumentor.tracingEnd(ctx, span)
+
+	response, err := h.handler.Invoke(ctx, payload)
+	if err != nil {
+		return nil, err
+	}
+
+	return response, nil
+}
+
+// WrapHandler Provides a Handler which wraps customer Handler with OTel Tracing.
+func WrapHandler(handler lambda.Handler, options ...Option) lambda.Handler {
+	return wrappedHandler{instrumentor: newInstrumentor(options...), handler: handler}
+}

--- a/vendor/go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-lambda-go/otellambda/wrapLambdaHandler.go
+++ b/vendor/go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-lambda-go/otellambda/wrapLambdaHandler.go
@@ -1,0 +1,176 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package otellambda // import "go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-lambda-go/otellambda"
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"reflect"
+)
+
+// wrappedHandlerFunction is a struct which only holds an instrumentor and is
+// able to instrument invocations of the user's lambda handler function.
+type wrappedHandlerFunction struct {
+	instrumentor instrumentor
+}
+
+func errorHandler(e error) func(context.Context, interface{}) (interface{}, error) {
+	return func(context.Context, interface{}) (interface{}, error) {
+		return nil, e
+	}
+}
+
+// Ensure handler takes 0-2 values, with context
+// as its first value if two arguments exist.
+func validateArguments(handler reflect.Type) (bool, error) {
+	handlerTakesContext := false
+	if handler.NumIn() > 2 {
+		return false, fmt.Errorf("handlers may not take more than two arguments, but handler takes %d", handler.NumIn())
+	} else if handler.NumIn() > 0 {
+		contextType := reflect.TypeOf((*context.Context)(nil)).Elem()
+		argumentType := handler.In(0)
+		handlerTakesContext = argumentType.Implements(contextType)
+		if handler.NumIn() > 1 && !handlerTakesContext {
+			return false, fmt.Errorf("handler takes two arguments, but the first is not Context. got %s", argumentType.Kind())
+		}
+	}
+
+	return handlerTakesContext, nil
+}
+
+// Ensure handler returns 0-2 values, with an error
+// as its first value if any exist.
+func validateReturns(handler reflect.Type) error {
+	errorType := reflect.TypeOf((*error)(nil)).Elem()
+
+	switch n := handler.NumOut(); {
+	case n > 2:
+		return fmt.Errorf("handler may not return more than two values")
+	case n == 2:
+		if !handler.Out(1).Implements(errorType) {
+			return fmt.Errorf("handler returns two values, but the second does not implement error")
+		}
+	case n == 1:
+		if !handler.Out(0).Implements(errorType) {
+			return fmt.Errorf("handler returns a single value, but it does not implement error")
+		}
+	}
+
+	return nil
+}
+
+// Wraps and calls customer lambda handler then unpacks response as necessary.
+func (whf *wrappedHandlerFunction) wrapperInternals(ctx context.Context, handlerFunc interface{}, eventJSON []byte, event reflect.Value, takesContext bool) (interface{}, error) {
+	wrappedLambdaHandler := reflect.ValueOf(whf.wrapper(handlerFunc))
+
+	argsWrapped := []reflect.Value{reflect.ValueOf(ctx), reflect.ValueOf(eventJSON), event, reflect.ValueOf(takesContext)}
+	response := wrappedLambdaHandler.Call(argsWrapped)[0].Interface().([]reflect.Value)
+
+	// convert return values into (interface{}, error)
+	var err error
+	if len(response) > 0 {
+		if errVal, ok := response[len(response)-1].Interface().(error); ok {
+			err = errVal
+		}
+	}
+	var val interface{}
+	if len(response) > 1 {
+		val = response[0].Interface()
+	}
+
+	return val, err
+}
+
+// InstrumentHandler Provides a lambda handler which wraps customer lambda handler with OTel Tracing.
+func InstrumentHandler(handlerFunc interface{}, options ...Option) interface{} {
+	whf := wrappedHandlerFunction{instrumentor: newInstrumentor(options...)}
+
+	if handlerFunc == nil {
+		return errorHandler(fmt.Errorf("handler is nil"))
+	}
+	handlerType := reflect.TypeOf(handlerFunc)
+	if handlerType.Kind() != reflect.Func {
+		return errorHandler(fmt.Errorf("handler kind %s is not %s", handlerType.Kind(), reflect.Func))
+	}
+
+	takesContext, err := validateArguments(handlerType)
+	if err != nil {
+		return errorHandler(err)
+	}
+
+	if err := validateReturns(handlerType); err != nil {
+		return errorHandler(err)
+	}
+
+	// note we will always take context to capture lambda context,
+	// regardless of whether customer takes context
+	if handlerType.NumIn() == 0 || handlerType.NumIn() == 1 && takesContext {
+		return func(ctx context.Context) (interface{}, error) {
+			var temp *interface{}
+			event := reflect.ValueOf(temp)
+			return whf.wrapperInternals(ctx, handlerFunc, []byte{}, event, takesContext)
+		}
+	}
+
+	// customer either takes both context and payload or just payload
+	return func(ctx context.Context, payload interface{}) (interface{}, error) {
+		event := reflect.New(handlerType.In(handlerType.NumIn() - 1))
+
+		// lambda SDK normally unmarshalls to customer event type, however
+		// with the wrapper the SDK unmarshalls to map[string]interface{}
+		// due to our use of reflection. Therefore we must convert this map
+		// to customer's desired event, we do so by simply re-marshaling then
+		// unmarshalling to the desired event type. The remarshalledPayload
+		// will also be used by users using custom propagators
+		remarshalledPayload, err := json.Marshal(payload)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(remarshalledPayload, event.Interface()); err != nil {
+			return nil, err
+		}
+
+		return whf.wrapperInternals(ctx, handlerFunc, remarshalledPayload, event.Elem(), takesContext)
+	}
+}
+
+// Adds OTel span surrounding customer handler call.
+func (whf *wrappedHandlerFunction) wrapper(handlerFunc interface{}) func(ctx context.Context, eventJSON []byte, event interface{}, takesContext bool) []reflect.Value {
+	return func(ctx context.Context, eventJSON []byte, event interface{}, takesContext bool) []reflect.Value {
+		ctx, span := whf.instrumentor.tracingBegin(ctx, eventJSON)
+		defer whf.instrumentor.tracingEnd(ctx, span)
+
+		handler := reflect.ValueOf(handlerFunc)
+		var args []reflect.Value
+		if takesContext {
+			args = append(args, reflect.ValueOf(ctx))
+		}
+		if eventExists(event) {
+			args = append(args, reflect.ValueOf(event))
+		}
+
+		response := handler.Call(args)
+
+		return response
+	}
+}
+
+// Determine if an interface{} is nil or the
+// if the reflect.Value of the event is nil.
+func eventExists(event interface{}) bool {
+	if event == nil {
+		return false
+	}
+
+	// reflect.Value.isNil() can only be called on
+	// Values of certain Kinds. Unsupported Kinds
+	// will panic rather than return false
+	switch reflect.TypeOf(event).Kind() {
+	case reflect.Chan, reflect.Func, reflect.Map, reflect.Ptr, reflect.UnsafePointer, reflect.Interface, reflect.Slice:
+		return !reflect.ValueOf(event).IsNil()
+	}
+	return true
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -229,6 +229,9 @@ go.opentelemetry.io/contrib/detectors/aws/lambda
 # go.opentelemetry.io/contrib/exporters/autoexport v0.52.0
 ## explicit; go 1.21
 go.opentelemetry.io/contrib/exporters/autoexport
+# go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-lambda-go/otellambda v0.52.0
+## explicit; go 1.21
+go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-lambda-go/otellambda
 # go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws v0.52.0
 ## explicit; go 1.21
 go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws


### PR DESCRIPTION
Wrap our existing mux instrumentation with the `otellambda` package. The upstream package sets a reasonable span name, kind, and injects attributes that are consistent with the `faas` semantic convention.

In order to attach the payload to every invocation we still need to provide our own Invoke method. The payload is added as an attribute.