### PR TITLE
fix: consistent userAgent for AWS SDK and HTTP

### DIFF
--- a/cmd/forwarder/main.go
+++ b/cmd/forwarder/main.go
@@ -114,7 +114,6 @@ func realInit() (err error) {
 
 	var s3Client forwarder.S3Client = awsS3Client
 	if strings.HasPrefix(env.DestinationURI, "https") {
-		userAgent := fmt.Sprintf("forwarder/%s", version.Version)
 		logger.V(4).Info("loading http client")
 		s3Client, err = s3http.New(&s3http.Config{
 			DestinationURI:     env.DestinationURI,
@@ -122,7 +121,6 @@ func realInit() (err error) {
 			HTTPClient: tracing.NewHTTPClient(&tracing.HTTPClientConfig{
 				TracerProvider: tracerProvider,
 				Logger:         &logger,
-				UserAgent:      &userAgent,
 			}),
 		})
 		if err != nil {

--- a/tracing/aws.go
+++ b/tracing/aws.go
@@ -3,11 +3,15 @@ package tracing
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/middleware"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws"
 	"go.opentelemetry.io/otel/trace"
+
+	"github.com/observeinc/aws-sam-apps/version"
 )
 
 func AWSLoadDefaultConfig(ctx context.Context, tracerProvider trace.TracerProvider) (aws.Config, error) {
@@ -15,6 +19,13 @@ func AWSLoadDefaultConfig(ctx context.Context, tracerProvider trace.TracerProvid
 	if err != nil {
 		return awsCfg, fmt.Errorf("failed to load AWS configuration: %w", err)
 	}
+
+	if serviceName := os.Getenv("OTEL_SERVICE_NAME"); serviceName != "" {
+		awsCfg.APIOptions = append(awsCfg.APIOptions,
+			middleware.AddUserAgentKeyValue(serviceName, version.Version),
+		)
+	}
+
 	otelaws.AppendMiddlewares(&awsCfg.APIOptions, otelaws.WithTracerProvider(tracerProvider))
 	return awsCfg, nil
 }


### PR DESCRIPTION
We should set user agent as part of our tracing package, rather than relying on each top level entry point for a handler to set it up. We will rely on the OTEL service name, which is consistently set as part of each lambda config.