### PR TITLE
fix(tracing): set flusher in otellambda instrumentation

### DIFF
--- a/tracing/mux.go
+++ b/tracing/mux.go
@@ -6,15 +6,17 @@ import (
 	"github.com/aws/aws-lambda-go/lambda"
 	"go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-lambda-go/otellambda"
 	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"
 )
 
 var payloadKey = attribute.Key("payload")
 
-func NewLambdaHandler(handler lambda.Handler, tp trace.TracerProvider) lambda.Handler {
+func NewLambdaHandler(handler lambda.Handler, tp *sdktrace.TracerProvider) lambda.Handler {
 	return otellambda.WrapHandler(
 		&LambdaHandler{handler},
 		otellambda.WithTracerProvider(tp),
+		otellambda.WithFlusher(tp),
 	)
 }
 


### PR DESCRIPTION
This ensures we flush data prior to lambda freezing.