### PR TITLE
fix(config): adjust precedence of parameters.

### DIFF
--- a/apps/config/template.yaml
+++ b/apps/config/template.yaml
@@ -109,16 +109,17 @@ Conditions:
       - ','
       - !Ref IncludeResourceTypes
   IncludeResources: !And
+    - !Condition EnableConfig
     - !Not
       - !Condition IncludeAllResources
+  ExcludeResources: !And
+    - !Condition IncludeAllResources
     - !Not
-      - !Condition ExcludeResources
-  ExcludeResources: !Not
-    - !Equals
-      - ''
-      - !Join
-        - ','
-        - !Ref ExcludeResourceTypes
+      - !Equals
+        - ''
+        - !Join
+          - ','
+          - !Ref ExcludeResourceTypes
   AllSupported: !And
     - !Condition IncludeAllResources
     - !Not
@@ -128,6 +129,7 @@ Conditions:
     - !Equals
       - !Ref IncludeGlobalResourceTypes
       - "true"
+
 Resources:
   ConfigurationRecorderRole:
     Type: AWS::IAM::Role

--- a/docs/config.md
+++ b/docs/config.md
@@ -29,3 +29,16 @@ The following parameters are required for stack configuration:
 | `IncludeGlobalResourceTypes` | String | Specifies whether AWS Config includes all supported types of global resources with the resources that it records. This field only takes effect if all resources are included for collection. IncludeResourceTypes must be set to *, and ExcludeResourceTypes must not be set. |
 | `Prefix` | String | The prefix for the specified Amazon S3 bucket. |
 | `DeliveryFrequency` | String | The frequency with which AWS Config delivers configuration snapshots. |
+
+## Filtering resource types
+
+AWS Config allows including _or_ excluding resource types. The following table summarizes possible configuration states for our stack:
+
+| `IncludeResourceTypes`             | `ExcludeResourceTypes`             | Description                                                                                             |
+|------------------------------------|------------------------------------|---------------------------------------------------------------------------------------------------------|
+|                                    |                                    | No recorder configured.                                                                                 |
+| *                                  |                                    | Record all resource types, including global resource types.                                             |
+| *                                  | AWS::S3::Bucket,AWS::EC2::Instance | Record all resource types, except for S3 buckets and EC2 instances. Global types are not recorded.      |
+| AWS::S3::Bucket,AWS::EC2::Instance |                                    | Record only S3 buckets and EC2 instances.                                                               |
+| AWS::S3::Bucket                    | AWS::EC2::Instance                 | Record only S3 buckets. `ExcludeResourceTypes` is ignored.                                              |
+|                                    | AWS::EC2::Instance                 | No recorder configured. `IncludeResourceTypes` cannot be empty.                                         |


### PR DESCRIPTION
The AWS Config API does not allow both exclusion and inclusion sets. We currently allow users to provide both, and prefer `ExcludeResourceTypes`, which can be misleading if the intent was to restrict collection further.

This commit changes precendence to prefer `IncludeResourceTypes` over `ExcludeResourceTypes`. The reasoning here is that the inclusion list tends to be small, in which case it is the cost conservative behavior.

An alternative approach would be to assert that only one of the sets is provided. Unfortunately errors in cloudformation are hard to debug, so the user experience would be terrible.