### PR TITLE
feat(forwarder): add `SourceObjectKeys`

### DIFF
--- a/apps/forwarder/template.yaml
+++ b/apps/forwarder/template.yaml
@@ -25,6 +25,7 @@ Metadata:
           default: Data Sources
         Parameters:
           - SourceBucketNames
+          - SourceObjectKeys
           - SourceTopicArns
           - SourceKMSKeyArns
           - ContentTypeOverrides
@@ -69,6 +70,12 @@ Parameters:
       to the forwarder.
     Default: ''
     AllowedPattern: "^[a-z0-9-.]*(\\*)?$"
+  SourceObjectKeys:
+    Type: CommaDelimitedList
+    Description: >-
+      A list of object keys which the forwarder should process. This list
+      applies across all source buckets, and supports wildcards.
+    Default: '*'
   SourceTopicArns:
     Type: CommaDelimitedList
     Description: >-
@@ -154,11 +161,17 @@ Conditions:
   UseDefaultVerbosity: !Equals
     - !Ref Verbosity
     - ''
-  DisableSourceS3: !Equals
-    - !Join
+  DisableSourceS3: !Or
+    - !Equals
+      - !Join
+        - ''
+        - !Ref SourceBucketNames
       - ''
-      - !Ref SourceBucketNames
-    - ''
+    - !Equals
+      - !Join
+        - ''
+        - !Ref SourceObjectKeys
+      - ''
   EnableSourceS3: !Not
     - !Condition DisableSourceS3
   DisableKMSDecrypt: !Equals
@@ -244,11 +257,15 @@ Resources:
           {
             "source": ["aws.s3"],
             "detail-type": ["Object Created"],
-            "detail.bucket.name": [{"wildcard": "${wildcards}"}]
+            "detail.bucket.name": [{"wildcard": "${buckets}"}],
+            "detail.object.key": [{"wildcard": "${objects}"}]
           }
-        - wildcards: !Join
+        - buckets: !Join
             - '"}, {"wildcard":"'
             - !Ref SourceBucketNames
+          objects: !Join
+            - '"}, {"wildcard":"'
+            - !Ref SourceObjectKeys
       Targets:
         - Arn: !GetAtt Queue.Arn
           Id: "Forwarder"
@@ -343,6 +360,14 @@ Resources:
                   Action:
                     - s3:GetObject
                     - s3:GetObjectTagging
+                  # NOTE: ideally we'd filter the resource list to the set of
+                  # source object keys. That would require taking the cross
+                  # product of SourceBucketNames and SourceObjectKeys, which
+                  # can not be natively expressed in CloudFormation.
+                  #
+                  # We rely instead on filtering within the Lambda function,
+                  # assisted by filtering at the event subscription layer to
+                  # reduce the chances of false positives.
                   Resource: !Split
                     - ","
                     - !Sub
@@ -435,6 +460,9 @@ Resources:
           SOURCE_BUCKET_NAMES: !Join
             - ','
             - !Ref SourceBucketNames
+          SOURCE_OBJECT_KEYS: !Join
+            - ','
+            - !Ref SourceObjectKeys
           OTEL_EXPORTER_OTLP_ENDPOINT: !Ref DebugEndpoint
           OTEL_TRACES_EXPORTER: !If [DisableOTEL, "none", "otlp"]
 Outputs:

--- a/pkg/handler/forwarder/config.go
+++ b/pkg/handler/forwarder/config.go
@@ -9,6 +9,7 @@ import (
 
 var (
 	ErrInvalidDestination = errors.New("invalid destination URI")
+	ErrInvalidFilter      = errors.New("invalid source filter")
 	ErrMissingS3Client    = errors.New("missing S3 client")
 	ErrPresetNotFound     = errors.New("not found")
 )
@@ -17,6 +18,7 @@ type Config struct {
 	DestinationURI    string // S3 URI to write messages and copy files to
 	MaxFileSize       int64  // maximum file size in bytes for the files to be processed
 	SourceBucketNames []string
+	SourceObjectKeys  []string
 	Override          Override
 	S3Client          S3Client
 	GetTime           func() *time.Time
@@ -37,6 +39,10 @@ func (c *Config) Validate() error {
 		default:
 			errs = append(errs, fmt.Errorf("%w: scheme must be \"s3\" or \"https\"", ErrInvalidDestination))
 		}
+	}
+
+	if _, err := NewObjectFilter(c.SourceBucketNames, c.SourceObjectKeys); err != nil {
+		errs = append(errs, fmt.Errorf("%w: %w", ErrInvalidFilter, err))
 	}
 
 	if c.S3Client == nil {

--- a/pkg/handler/forwarder/config_test.go
+++ b/pkg/handler/forwarder/config_test.go
@@ -35,6 +35,14 @@ func TestConfig(t *testing.T) {
 			},
 			ExpectError: forwarder.ErrInvalidDestination,
 		},
+		{
+			Config: forwarder.Config{
+				DestinationURI:    "https://example.com",
+				S3Client:          &awstest.S3Client{},
+				SourceBucketNames: []string{"bucket*"},
+				SourceObjectKeys:  []string{"*/te?t/*"},
+			},
+		},
 	}
 
 	for i, tc := range testcases {

--- a/pkg/handler/forwarder/filter.go
+++ b/pkg/handler/forwarder/filter.go
@@ -1,0 +1,44 @@
+package forwarder
+
+import (
+	"fmt"
+	"regexp"
+)
+
+var globOperators = regexp.MustCompile(`(\*|\?)`)
+
+// ObjectFilter verifies if object is intended for processing
+type ObjectFilter struct {
+	filters []*regexp.Regexp
+}
+
+// Allow verifies if object source should be accessed
+func (o *ObjectFilter) Allow(source string) bool {
+	for _, re := range o.filters {
+		if re.MatchString(source) {
+			return true
+		}
+	}
+	return false
+}
+
+// NewObjectFilter initializes an ObjectFilter.
+// This function will error if any bucket or object pattern are not valid glob expressions.
+func NewObjectFilter(names, keys []string) (*ObjectFilter, error) {
+	var obj ObjectFilter
+	// TODO: for simplicity we compute the cross product of regular expressions. It
+	// would be more efficient to verify buckets and object key separately, but
+	// we don't expect either list to be very long.
+
+	for _, name := range names {
+		for _, key := range keys {
+			source := name + "/" + key
+			re, err := regexp.Compile(globOperators.ReplaceAllString(source, ".$1"))
+			if err != nil {
+				return nil, fmt.Errorf("failed to compile %s: %w", source, err)
+			}
+			obj.filters = append(obj.filters, re)
+		}
+	}
+	return &obj, nil
+}

--- a/pkg/handler/forwarder/handler_test.go
+++ b/pkg/handler/forwarder/handler_test.go
@@ -123,6 +123,7 @@ func TestHandler(t *testing.T) {
 				MaxFileSize:       20,
 				DestinationURI:    "s3://my-bucket",
 				SourceBucketNames: []string{"observeinc*"},
+				SourceObjectKeys:  []string{"*"},
 				S3Client: &awstest.S3Client{
 					CopyObjectFunc: func(_ context.Context, _ *s3.CopyObjectInput, _ ...func(*s3.Options)) (*s3.CopyObjectOutput, error) {
 						return nil, nil
@@ -141,6 +142,7 @@ func TestHandler(t *testing.T) {
 				MaxFileSize:       1,
 				DestinationURI:    "s3://my-bucket",
 				SourceBucketNames: []string{"observeinc*"},
+				SourceObjectKeys:  []string{"*"},
 				S3Client: &awstest.S3Client{
 					CopyObjectFunc: func(_ context.Context, _ *s3.CopyObjectInput, _ ...func(*s3.Options)) (*s3.CopyObjectOutput, error) {
 						return nil, nil
@@ -158,6 +160,7 @@ func TestHandler(t *testing.T) {
 			Config: forwarder.Config{
 				DestinationURI:    "s3://my-bucket",
 				SourceBucketNames: []string{"observeinc*"},
+				SourceObjectKeys:  []string{"*"},
 				S3Client: &awstest.S3Client{
 					CopyObjectFunc: func(_ context.Context, _ *s3.CopyObjectInput, _ ...func(*s3.Options)) (*s3.CopyObjectOutput, error) {
 						return nil, errSentinel
@@ -177,6 +180,7 @@ func TestHandler(t *testing.T) {
 			Config: forwarder.Config{
 				DestinationURI:    "s3://my-bucket",
 				SourceBucketNames: []string{"observeinc*"},
+				SourceObjectKeys:  []string{"*"},
 				S3Client: &awstest.S3Client{
 					PutObjectFunc: func(_ context.Context, _ *s3.PutObjectInput, _ ...func(*s3.Options)) (*s3.PutObjectOutput, error) {
 						return nil, errSentinel
@@ -192,6 +196,25 @@ func TestHandler(t *testing.T) {
 			Config: forwarder.Config{
 				DestinationURI:    "s3://my-bucket",
 				SourceBucketNames: []string{"doesntexist"},
+				SourceObjectKeys:  []string{"*"},
+				S3Client: &awstest.S3Client{
+					CopyObjectFunc: func(_ context.Context, _ *s3.CopyObjectInput, _ ...func(*s3.Options)) (*s3.CopyObjectOutput, error) {
+						return nil, nil
+					},
+				},
+			},
+			ExpectedCopyCalls: 0,
+			ExpectResponse:    events.SQSEventResponse{
+				// Expect no batch item failures as the file should be skipped, not failed
+			},
+		},
+		{
+			// Source key isn't in source object keys
+			RequestFile: "testdata/event.json",
+			Config: forwarder.Config{
+				DestinationURI:    "s3://my-bucket",
+				SourceBucketNames: []string{"*"},
+				SourceObjectKeys:  []string{"nope"},
 				S3Client: &awstest.S3Client{
 					CopyObjectFunc: func(_ context.Context, _ *s3.CopyObjectInput, _ ...func(*s3.Options)) (*s3.CopyObjectOutput, error) {
 						return nil, nil
@@ -210,6 +233,7 @@ func TestHandler(t *testing.T) {
 				MaxFileSize:       50, // Adjust size limit to allow the file to be copied
 				DestinationURI:    "s3://my-bucket",
 				SourceBucketNames: []string{"doesntexist", "observeinc-filedrop-hoho-us-west-2-7xmjt"}, // List includes the exact bucket name
+				SourceObjectKeys:  []string{"ds*"},
 				S3Client: &awstest.S3Client{
 					CopyObjectFunc: func(_ context.Context, _ *s3.CopyObjectInput, _ ...func(*s3.Options)) (*s3.CopyObjectOutput, error) {
 						return nil, nil // Mock successful copy
@@ -227,6 +251,7 @@ func TestHandler(t *testing.T) {
 			Config: forwarder.Config{
 				DestinationURI:    "s3://my-bucket",
 				SourceBucketNames: []string{"observeinc*"},
+				SourceObjectKeys:  []string{"*"},
 				S3Client: &awstest.S3Client{
 					CopyObjectFunc: func(_ context.Context, _ *s3.CopyObjectInput, _ ...func(*s3.Options)) (*s3.CopyObjectOutput, error) {
 						return nil, nil // Mock successful copy
@@ -244,6 +269,7 @@ func TestHandler(t *testing.T) {
 			Config: forwarder.Config{
 				DestinationURI:    "s3://my-bucket",
 				SourceBucketNames: []string{"observeinc*"},
+				SourceObjectKeys:  []string{"*"},
 				S3Client: &awstest.S3Client{
 					CopyObjectFunc: func(_ context.Context, _ *s3.CopyObjectInput, _ ...func(*s3.Options)) (*s3.CopyObjectOutput, error) {
 						return nil, errSentinel

--- a/pkg/lambda/forwarder/lambda.go
+++ b/pkg/lambda/forwarder/lambda.go
@@ -37,6 +37,7 @@ type Config struct {
 	ContentTypeOverrides []*override.Rule `env:"CONTENT_TYPE_OVERRIDES"`
 	PresetOverrides      []string         `env:"PRESET_OVERRIDES,default=aws/v1,infer/v1"`
 	SourceBucketNames    []string         `env:"SOURCE_BUCKET_NAMES"`
+	SourceObjectKeys     []string         `env:"SOURCE_OBJECT_KEYS"`
 
 	Logging *logging.Config
 
@@ -140,6 +141,7 @@ func New(ctx context.Context, cfg *Config) (*Lambda, error) {
 		S3Client:          s3Client,
 		Override:          append(override.Sets{customOverrides}, presets...),
 		SourceBucketNames: cfg.SourceBucketNames,
+		SourceObjectKeys:  cfg.SourceObjectKeys,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create handler: %w", err)


### PR DESCRIPTION
This commit adds the ability to specify a set of patterns which identify object keys we are willing to forward.

A new parameter, `SourceObjectKeys`, allows specifying a set of key patterns against which incoming objects are filtered. We also use this parameter to further constrict our eventbridge pattern for triggering the lambda function.