### PR TITLE
fix(logwriter): trigger on update

### DIFF
--- a/apps/logwriter/template.yaml
+++ b/apps/logwriter/template.yaml
@@ -27,6 +27,7 @@ Metadata:
         Parameters:
           - LogGroupNamePatterns
           - LogGroupNamePrefixes
+          - ExcludeLogGroupNamePatterns
           - DiscoveryRate
           - FilterName
           - FilterPattern
@@ -74,7 +75,7 @@ Parameters:
   ExcludeLogGroupNamePatterns:
     Type: CommaDelimitedList
     Description: >-
-      Comma separated list of patterns. This paramter is used to filter out log
+      Comma separated list of patterns. This parameter is used to filter out log
       groups from subscription, and supports the use of regular expressions.
     Default: ''
   DiscoveryRate:
@@ -543,6 +544,31 @@ Resources:
               - HasLogGroupNamePrefixes
               - !Ref LogGroupNamePrefixes
               - []
+  Trigger:
+    Type: Custom::Trigger
+    Condition: HasDiscoveryRate
+    DependsOn:
+      - DiscoverySchedule
+    Properties:
+      ServiceTimeout: 60
+      ServiceToken: !GetAtt Subscriber.Arn
+      # List all parameters here, any change will trigger update
+      BucketArn: !Ref BucketArn
+      Prefix: !Ref Prefix
+      LogGroupNamePatterns: !Ref LogGroupNamePatterns
+      LogGroupNamePrefixes: !Ref LogGroupNamePrefixes
+      ExcludeLogGroupNamePatterns: !Ref ExcludeLogGroupNamePatterns
+      DiscoveryRate: !Ref DiscoveryRate
+      FilterName: !Ref FilterName
+      FilterPattern: !Ref FilterPattern
+      NameOverride: !Ref NameOverride
+      BufferingInterval: !Ref BufferingInterval
+      BufferingSize: !Ref BufferingSize
+      NumWorkers: !Ref NumWorkers
+      MemorySize: !Ref MemorySize
+      Timeout: !Ref Timeout
+      DebugEndpoint: !Ref DebugEndpoint
+      Verbosity: !Ref Verbosity
 Outputs:
   FirehoseArn:
     Description: >-

--- a/docs/logwriter.md
+++ b/docs/logwriter.md
@@ -43,7 +43,7 @@ You can optionally enable automatic log group subscription. Configuring either `
 | `Prefix` | String | Optional prefix to write log records to. |
 | `LogGroupNamePatterns` | CommaDelimitedList | Comma separated list of patterns. We will only subscribe to log groups that have names matching any of the provided strings based on a case-sensitive substring search. See the AWS `DescribeLogGroups` action for more information. To subscribe to all log groups, use the wildcard operator *. |
 | `LogGroupNamePrefixes` | CommaDelimitedList | Comma separated list of prefixes. The lambda function will only apply to log groups that start with a provided string. To subscribe to all log groups, use the wildcard operator *. |
-| `ExcludeLogGroupNamePatterns` | CommaDelimitedList | Comma separated list of patterns. This paramter is used to filter out log groups from subscription, and supports the use of regular expressions. |
+| `ExcludeLogGroupNamePatterns` | CommaDelimitedList | Comma separated list of patterns. This parameter is used to filter out log groups from subscription, and supports the use of regular expressions. |
 | `DiscoveryRate` | String | EventBridge rate expression for periodically triggering discovery. If not set, no eventbridge rules are configured. |
 | `FilterName` | String | Subscription filter name. Existing filters that have this name as a prefix will be removed. |
 | `FilterPattern` | String | Subscription filter pattern. |

--- a/integration/tests/logwriter.tftest.hcl
+++ b/integration/tests/logwriter.tftest.hcl
@@ -45,10 +45,14 @@ variables {
           "lambda:DeleteFunction",
           "lambda:GetEventSourceMapping",
           "lambda:GetFunction",
+          "lambda:InvokeFunction",
           "lambda:ListEventSourceMappings",
+          "lambda:ListTags",
           "lambda:TagResource",
           "lambda:UntagResource",
           "lambda:UpdateEventSourceMapping",
+          "lambda:UpdateFunctionCode",
+          "lambda:UpdateFunctionConfiguration",
           "logs:CreateLogGroup",
           "logs:CreateLogStream",
           "logs:DeleteLogGroup",
@@ -128,5 +132,23 @@ run "check_eventbridge_invoked" {
   assert {
     condition     = output.error == ""
     error_message = "Failed to verify subscriber invocation"
+  }
+}
+
+run "update" {
+  variables {
+    setup = run.setup
+    app   = "logwriter"
+    parameters = {
+      BucketArn            = run.create_bucket.arn
+      LogGroupNamePatterns = "*"
+      DiscoveryRate        = "24 hours"
+      NameOverride         = run.setup.id
+      Verbosity            = 4
+    }
+    capabilities = [
+      "CAPABILITY_IAM",
+      "CAPABILITY_AUTO_EXPAND",
+    ]
   }
 }

--- a/integration/tests/stack.tftest.hcl
+++ b/integration/tests/stack.tftest.hcl
@@ -64,6 +64,7 @@ variables {
           "lambda:GetFunction",
           "lambda:GetFunctionCodeSigningConfig",
           "lambda:GetRuntimeManagementConfig",
+          "lambda:InvokeFunction",
           "lambda:ListEventSourceMappings",
           "lambda:ListTags",
           "lambda:TagResource",

--- a/pkg/handler/subscriber/cloudformation.go
+++ b/pkg/handler/subscriber/cloudformation.go
@@ -1,0 +1,91 @@
+package subscriber
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/aws/aws-lambda-go/cfn"
+	"github.com/aws/aws-lambda-go/lambdacontext"
+	"github.com/go-logr/logr"
+)
+
+var (
+	ErrMalformedEvent = errors.New("malformed cloudformation event")
+)
+
+// CloudFormationEvent adds a field which is not declared in cloudformation package
+type CloudFormationEvent struct {
+	*cfn.Event
+}
+
+// UnmarshalJSON provides a custom unmarshaller that allows unknown fields.
+// It is critical that we respond to any CloudFormation event, otherwise stack
+// install, updates and deletes will stall. In order to protect ourselves
+// against unexpected fields, we succeed unmarshalling so long as we have the
+// necessary elements to form a response.
+func (c *CloudFormationEvent) UnmarshalJSON(data []byte) error {
+	if err := json.Unmarshal(data, &c.Event); err != nil {
+		return err
+	}
+
+	switch {
+	case c.RequestID == "":
+	case c.ResponseURL == "":
+	case c.LogicalResourceID == "":
+	case c.StackID == "":
+	default:
+		return nil
+	}
+
+	return fmt.Errorf("not a cloudformation event")
+}
+
+func makeStrSlice(item any) ([]*string, error) {
+	vs, ok := item.([]any)
+	if !ok {
+		return nil, fmt.Errorf("failed to cast %v to slice", item)
+	}
+	var ret []*string
+	for _, v := range vs {
+		s, ok := v.(string)
+		if !ok {
+			return nil, fmt.Errorf("failed to cast %v to string", v)
+		}
+		ret = append(ret, &s)
+	}
+	return ret, nil
+}
+
+// HandleCloudFormation triggers discovery on CloudFormation stack updates
+func (h *Handler) HandleCloudFormation(ctx context.Context, ev *CloudFormationEvent) (*Response, error) {
+	logger := logr.FromContextOrDiscard(ctx)
+
+	if ev == nil {
+		return &Response{}, nil
+	}
+
+	logger.V(3).Info("handling cloudformation event", "requestType", ev.RequestType)
+
+	response := cfn.NewResponse(ev.Event)
+	response.PhysicalResourceID = lambdacontext.LogStreamName
+	response.Status = cfn.StatusSuccess
+	err := response.Send()
+	if err != nil {
+		return nil, fmt.Errorf("failed to send cloudformation response: %w", err)
+	}
+
+	if ev.RequestType == cfn.RequestUpdate {
+		var req DiscoveryRequest
+		if req.LogGroupNamePatterns, err = makeStrSlice(ev.ResourceProperties["LogGroupNamePatterns"]); err != nil {
+			return nil, fmt.Errorf("failed to extract logGroupNamePatterns: %w", err)
+		}
+		if req.LogGroupNamePrefixes, err = makeStrSlice(ev.ResourceProperties["LogGroupNamePrefixes"]); err != nil {
+			return nil, fmt.Errorf("failed to extract logGroupNamePrefixes: %w", err)
+		}
+		return h.HandleDiscoveryRequest(ctx, &req)
+	}
+
+	return &Response{}, nil
+}

--- a/pkg/lambda/subscriber/lambda.go
+++ b/pkg/lambda/subscriber/lambda.go
@@ -121,7 +121,7 @@ func New(ctx context.Context, cfg *Config) (*Lambda, error) {
 		Logger: logger,
 	}
 
-	if err := mux.Register(is.HandleRequest, is.HandleSQS); err != nil {
+	if err := mux.Register(is.HandleRequest, is.HandleSQS, is.HandleCloudFormation); err != nil {
 		return nil, fmt.Errorf("failed to register functions: %w", err)
 	}
 

--- a/vendor/github.com/aws/aws-lambda-go/cfn/README.md
+++ b/vendor/github.com/aws/aws-lambda-go/cfn/README.md
@@ -1,0 +1,36 @@
+# Overview
+
+CloudFormation has a different way of responding to most events due to the way stacks execute.
+
+It is best to catch all errors and ensure the correct response is sent to the pre-signed URL that comes with the event.
+
+To make this easier, a wrapper exists to allow the creation of custom resources without having to handle that.
+
+# Sample Function
+
+This sample will safely 'Echo' back anything given into the Echo parameter within the Custom Resource call.
+
+```go
+
+import (
+    "context"
+    "fmt"
+
+    "github.com/aws/aws-lambda-go/cfn"
+    "github.com/aws/aws-lambda-go/lambda"
+)
+
+func echoResource(ctx context.Context, event cfn.Event) (physicalResourceID string, data map[string]interface{}, err error) {
+    v, _ := event.ResourceProperties["Echo"].(string)
+
+    data = map[string]interface{} {
+        "Echo": v,
+    }
+
+    return
+}
+
+func main() {
+	lambda.Start(cfn.LambdaWrap(echoResource))
+}
+```

--- a/vendor/github.com/aws/aws-lambda-go/cfn/event.go
+++ b/vendor/github.com/aws/aws-lambda-go/cfn/event.go
@@ -1,0 +1,27 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+package cfn
+
+// RequestType represents the types of requests that
+// come from a CloudFormation stack being run
+type RequestType string
+
+const (
+	RequestCreate RequestType = "Create"
+	RequestUpdate RequestType = "Update"
+	RequestDelete RequestType = "Delete"
+)
+
+// Event is a representation of a Custom Resource
+// request
+type Event struct {
+	RequestType           RequestType            `json:"RequestType"`
+	RequestID             string                 `json:"RequestId"`
+	ResponseURL           string                 `json:"ResponseURL"`
+	ResourceType          string                 `json:"ResourceType"`
+	PhysicalResourceID    string                 `json:"PhysicalResourceId,omitempty"`
+	LogicalResourceID     string                 `json:"LogicalResourceId"`
+	StackID               string                 `json:"StackId"`
+	ResourceProperties    map[string]interface{} `json:"ResourceProperties"`
+	OldResourceProperties map[string]interface{} `json:"OldResourceProperties,omitempty"`
+}

--- a/vendor/github.com/aws/aws-lambda-go/cfn/response.go
+++ b/vendor/github.com/aws/aws-lambda-go/cfn/response.go
@@ -1,0 +1,89 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+package cfn
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil" //nolint: staticcheck
+	"log"
+	"net/http"
+)
+
+// StatusType represents a CloudFormation response status
+type StatusType string
+
+const (
+	StatusSuccess StatusType = "SUCCESS"
+	StatusFailed  StatusType = "FAILED"
+)
+
+// Response is a representation of a Custom Resource
+// response expected by CloudFormation.
+type Response struct {
+	Status             StatusType             `json:"Status"`
+	RequestID          string                 `json:"RequestId"`
+	LogicalResourceID  string                 `json:"LogicalResourceId"`
+	StackID            string                 `json:"StackId"`
+	PhysicalResourceID string                 `json:"PhysicalResourceId"`
+	Reason             string                 `json:"Reason,omitempty"`
+	NoEcho             bool                   `json:"NoEcho,omitempty"`
+	Data               map[string]interface{} `json:"Data,omitempty"`
+
+	url string
+}
+
+// NewResponse creates a Response with the relevant verbatim copied
+// data from a Event
+func NewResponse(r *Event) *Response {
+	return &Response{
+		RequestID:         r.RequestID,
+		LogicalResourceID: r.LogicalResourceID,
+		StackID:           r.StackID,
+
+		url: r.ResponseURL,
+	}
+}
+
+type httpClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+func (r *Response) sendWith(client httpClient) error {
+	body, err := json.Marshal(r)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest(http.MethodPut, r.url, bytes.NewBuffer(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Del("Content-Type")
+
+	res, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+
+	body, err = ioutil.ReadAll(res.Body)
+	if err != nil {
+		return err
+	}
+	res.Body.Close()
+
+	if res.StatusCode != 200 {
+		log.Printf("StatusCode: %d\nBody: %v\n", res.StatusCode, string(body))
+		return fmt.Errorf("invalid status code. got: %d", res.StatusCode)
+	}
+
+	return nil
+
+}
+
+// Send will send the Response to the given URL using the
+// default HTTP client
+func (r *Response) Send() error {
+	return r.sendWith(http.DefaultClient)
+}

--- a/vendor/github.com/aws/aws-lambda-go/cfn/wrap.go
+++ b/vendor/github.com/aws/aws-lambda-go/cfn/wrap.go
@@ -1,0 +1,105 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+package cfn
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log"
+	"net/http"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambdacontext"
+)
+
+// CustomResourceLambdaFunction is a standard form Lambda for a Custom Resource.
+type CustomResourceLambdaFunction func(context.Context, Event) (reason string, err error)
+
+// SNSCustomResourceLambdaFunction is a standard form Lambda for a Custom Resource
+// that is triggered via a SNS topic.
+type SNSCustomResourceLambdaFunction func(context.Context, events.SNSEvent) (reason string, err error)
+
+// CustomResourceFunction is a representation of the customer's Custom Resource function.
+// LambdaWrap will take the returned values and turn them into a response to be sent
+// to CloudFormation.
+type CustomResourceFunction func(context.Context, Event) (physicalResourceID string, data map[string]interface{}, err error)
+
+func lambdaWrapWithClient(lambdaFunction CustomResourceFunction, client httpClient) (fn CustomResourceLambdaFunction) {
+	fn = func(ctx context.Context, event Event) (reason string, err error) {
+		r := NewResponse(&event)
+
+		funcDidPanic := true
+		defer func() {
+			if funcDidPanic {
+				r.Status = StatusFailed
+				r.Reason = "Function panicked, see log stream for details"
+				// FIXME: something should be done if an error is returned here
+				_ = r.sendWith(client)
+			}
+		}()
+
+		r.PhysicalResourceID, r.Data, err = lambdaFunction(ctx, event)
+		funcDidPanic = false
+
+		if err != nil {
+			r.Status = StatusFailed
+			r.Reason = err.Error()
+			log.Printf("sending status failed: %s", r.Reason)
+		} else {
+			r.Status = StatusSuccess
+
+			if r.PhysicalResourceID == "" {
+				log.Println("PhysicalResourceID must exist on creation, copying Log Stream name")
+				r.PhysicalResourceID = lambdacontext.LogStreamName
+			}
+		}
+
+		err = r.sendWith(client)
+		if err != nil {
+			reason = err.Error()
+		}
+
+		return
+	}
+
+	return
+}
+
+// LambdaWrap returns a CustomResourceLambdaFunction which is something lambda.Start()
+// will understand. The purpose of doing this is so that Response Handling boiler
+// plate is taken away from the customer and it makes writing a Custom Resource
+// simpler.
+//
+//	func myLambda(ctx context.Context, event cfn.Event) (physicalResourceID string, data map[string]interface{}, err error) {
+//		physicalResourceID = "arn:...."
+//		return
+//	}
+//
+//	func main() {
+//		lambda.Start(cfn.LambdaWrap(myLambda))
+//	}
+func LambdaWrap(lambdaFunction CustomResourceFunction) (fn CustomResourceLambdaFunction) {
+	return lambdaWrapWithClient(lambdaFunction, http.DefaultClient)
+}
+
+// LambdaWrapSNS wraps a Lambda handler with support for SNS-based custom
+// resources. Usage and purpose otherwise same as LambdaWrap().
+func LambdaWrapSNS(lambdaFunction CustomResourceFunction) SNSCustomResourceLambdaFunction {
+	inner := LambdaWrap(lambdaFunction)
+	return func(ctx context.Context, event events.SNSEvent) (reason string, err error) {
+		if len(event.Records) != 1 {
+			err = errors.New("expected exactly 1 incoming record")
+			return
+		}
+
+		message := event.Records[0].SNS.Message
+
+		var innerEvent Event
+		if err = json.Unmarshal([]byte(message), &innerEvent); err != nil {
+			return
+		}
+
+		return inner(ctx, innerEvent)
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,5 +1,6 @@
 # github.com/aws/aws-lambda-go v1.47.0
 ## explicit; go 1.18
+github.com/aws/aws-lambda-go/cfn
 github.com/aws/aws-lambda-go/events
 github.com/aws/aws-lambda-go/lambda
 github.com/aws/aws-lambda-go/lambda/handlertrace


### PR DESCRIPTION
It is common practice to iteratively adjust parameters in the logwriter stack and refine filters through trial and error. Previously, log discovery and subscription would only run once our scheduler fired. This commit additionally ensures we manually trigger the lambda on any parameter change to our CloudFormation stack.

The commit adds:
- a custom resource to our CloudFormation logwriter stack which embeds all parameters. Any change to our input parameters will generate a CloudFormation event which triggers the subscriber Lambda function.
- a handler to the subscriber Lambda function which processes CloudFormation events. On stack updates, we will initiate a discovery request. We do not need to do any handling on install, since the scheduler will fire on first time install.
- a step to our integration tests which updates the stack to exercise the new functionality. IAM permissions were added to account for new behavior.

CloudFormation triggers are notoriously fussy. Our lambda must respond promptly, or risk holding up the CloudFormation process for an inordinately long time. To avoid this fate, this commit:
- is liberal in what it accepts as a CloudFormation event. Any payload that has sufficient metadata to generate a response will be interpreted as being valid. This ensures we are future proof to any schema extensions.
- immediately acknowledges the CloudFormation event before initiating discovery in order to not hold up install / update / delete process.