### PR TITLE
fix(logwriter): tighten up parameter patterns

### DIFF
--- a/apps/logwriter/template.yaml
+++ b/apps/logwriter/template.yaml
@@ -64,6 +64,7 @@ Parameters:
       `DescribeLogGroups` action for more information.
       To subscribe to all log groups, use the wildcard operator *.
     Default: ''
+    AllowedPattern: '^(\*|[a-zA-Z0-9-_\/]*)$'
   LogGroupNamePrefixes:
     Type: CommaDelimitedList
     Description: >-
@@ -71,6 +72,7 @@ Parameters:
       log groups that start with a provided string. To subscribe to all log
       groups, use the wildcard operator *.
     Default: ''
+    AllowedPattern: '^(\*|[a-zA-Z0-9-_\/]*)$'
   ExcludeLogGroupNamePatterns:
     Type: CommaDelimitedList
     Description: >-

--- a/apps/stack/template.yaml
+++ b/apps/stack/template.yaml
@@ -89,12 +89,14 @@ Parameters:
       only apply to log groups that have names that match one of the provided
       strings based on a case-sensitive substring search.
     Default: ''
+    AllowedPattern: '^(\*|[a-zA-Z0-9-_\/]*)$'
   LogGroupNamePrefixes:
     Type: CommaDelimitedList
     Description: >-
       Comma separated list of prefixes. If not empty, the lambda function will
       only apply to log groups that start with a provided string.
     Default: ''
+    AllowedPattern: '^(\*|[a-zA-Z0-9-_\/]*)$'
   ExcludeLogGroupNamePatterns:
     Type: CommaDelimitedList
     Description: >-


### PR DESCRIPTION
`LogGroupNamePatterns` and `LogGroupNamePrefixes` do not support regular expressions. Constraining the allowed pattern for either parameter ensures we error out early if a user attempts to pass in a regular expression.