### PR TITLE
fix: OB-38134 make parent stack outputs conditioned on nested stack

### DIFF
--- a/apps/stack/template.yaml
+++ b/apps/stack/template.yaml
@@ -220,7 +220,21 @@ Conditions:
     - !Equals
       - !Ref DatasourceID
       - ""
-
+  HasLogGroupNamePatterns: !Not
+    - !Equals
+      - !Join
+        - ','
+        - !Ref LogGroupNamePatterns
+      - ''
+  HasLogGroupNamePrefixes: !Not
+    - !Equals
+      - !Join
+        - ','
+        - !Ref LogGroupNamePrefixes
+      - ''
+  EnableSubscription: !Or
+    - !Condition HasLogGroupNamePatterns
+    - !Condition HasLogGroupNamePrefixes
 Resources:
   Topic:
     Type: "AWS::SNS::Topic"
@@ -452,6 +466,7 @@ Outputs:
     Description: >-
       Subscriber Function ARN. This function is responsible for log group
       discovery, filtering and subscription.
+    Condition: EnableSubscription
     Value: !GetAtt
       - LogWriter
       - Outputs.SubscriberArn
@@ -459,6 +474,7 @@ Outputs:
     Description: >-
       LogWriter Subscriber Queue ARN. This queue is used by the subscriber
       function to fan out execution of subscription requests.
+    Condition: EnableSubscription
     Value: !GetAtt
       - LogWriter
       - Outputs.SubscriberQueueArn
@@ -466,6 +482,7 @@ Outputs:
     Description: >-
       LogWriter Subscriber Log Group Name. This log group contains useful
       information for debugging the Subscriber function.
+    Condition: EnableSubscription
     Value: !GetAtt
       - LogWriter
       - Outputs.SubscriberLogGroupName


### PR DESCRIPTION
fix to correct logs to work when subscriber is not enabled