### PR TITLE
feat: bump runtime to provided.al2023

### DIFF
--- a/apps/forwarder/template.yaml
+++ b/apps/forwarder/template.yaml
@@ -420,7 +420,7 @@ Resources:
       Role: !GetAtt Role.Arn
       CodeUri: ../../bin/linux_arm64
       Handler: bootstrap
-      Runtime: provided.al2
+      Runtime: provided.al2023
       MemorySize: !If
         - UseDefaultMemorySize
         - !If

--- a/apps/logwriter/template.yaml
+++ b/apps/logwriter/template.yaml
@@ -427,7 +427,7 @@ Resources:
       Role: !GetAtt SubscriberRole.Arn
       CodeUri: ../../bin/linux_arm64
       Handler: bootstrap
-      Runtime: provided.al2
+      Runtime: provided.al2023
       MemorySize: !If
         - UseDefaultMemorySize
         - "128"

--- a/apps/metricstream/template.yaml
+++ b/apps/metricstream/template.yaml
@@ -292,7 +292,7 @@ Resources:
       Role: !GetAtt MetricsConfiguratorRole.Arn
       CodeUri: ../../bin/linux_arm64
       Handler: bootstrap
-      Runtime: provided.al2
+      Runtime: provided.al2023
       Architectures:
         - arm64
       LoggingConfig:


### PR DESCRIPTION
This should provide no functional difference, simply bumps us to latest and greatest.