### PR TITLE
docs: clarify when filterUri is overridden

### DIFF
--- a/apps/metricstream/template.yaml
+++ b/apps/metricstream/template.yaml
@@ -80,7 +80,9 @@ Parameters:
   DatasourceID:
     Type: String
     Description: >-
-      The datasource for this metric stream.
+      The datasource for this metric stream. Providing this will override
+      the MetricStreamFilterUri. The configuration from the datasource
+      will be used instead.
     Default: ''
     AllowedPattern: '\d*'
   GQLToken:

--- a/apps/stack/template.yaml
+++ b/apps/stack/template.yaml
@@ -144,7 +144,9 @@ Parameters:
   DatasourceID:
     Type: String
     Description: >-
-      The datasource for this metric stream.
+      The datasource for this metric stream. Providing this will override
+      the MetricStreamFilterUri. The configuration from the datasource
+      will be used instead.
     AllowedPattern: '\d*'
     Default: ''
   GQLToken:

--- a/docs/metricstream.md
+++ b/docs/metricstream.md
@@ -19,7 +19,7 @@ The application is configurable through several parameters that determine how da
 | `BufferingSize` | Number | Buffer incoming data to the specified size, in MiBs, before delivering it to the destination.  |
 | `ObserveAccountID` | String | The observe account id of the user.  |
 | `ObserveDomainName` | String | The domain name (e.g. `observe-eng.com`) that the user is making the request from.  |
-| `DatasourceID` | String | The datasource for this metric stream. If this is provided, the metric stream will not reflect the config in `MetricStreamFilterUri`, the config in `DatasourceID` will be applied instead. |
+| `DatasourceID` | String | The datasource for this metric stream. Providing this will override the `MetricStreamFilterUri`. The configuration from the datasource will be used instead. |
 | `GQLToken` | String | The token used to retrieve metric configuration from the Observe backend.  |
 | `UpdateTimestamp` | String | Unix timestamp when metric stream was created or updated.  |
 

--- a/docs/stack.md
+++ b/docs/stack.md
@@ -37,7 +37,7 @@ The Observe stack provisions the following components:
 | `MetricStreamFilterUri` | String | S3 URI for a file containing filters for metrics to be collected by CloudWatch Metrics Stream. If neither this nor DatasourceID is provided, no metrics will be collected. |
 | `ObserveAccountID` | String | The observe account id of the user.  |
 | `ObserveDomainName` | String | The domain name (e.g. `observe-eng.com`) that the user is making the request from.  |
-| `DatasourceID` | String | The datasource for this metric stream. If this is provided, the metric stream will not reflect the config in `MetricStreamFilterUri`, the config in `DatasourceID` will be applied instead.  |
+| `DatasourceID` | String | The datasource for this metric stream. Providing this will override the `MetricStreamFilterUri`. The configuration from the datasource will be used instead. |
 | `GQLToken` | String | The token used to retrieve metric configuration from the Observe backend.  |
 | `UpdateTimestamp` | String | Unix timestamp when metric stream was created or updated.  |
 | `SourceBucketNames` | CommaDelimitedList | A list of bucket names which the forwarder is allowed to read from. |


### PR DESCRIPTION
This makes updates to the docs, and also the comment under the input fields in the cloudformation stack creation page.