### PR TITLE
chore: add ecr image push for orca

### DIFF
--- a/.github/workflows/orca.yaml
+++ b/.github/workflows/orca.yaml
@@ -44,7 +44,10 @@ jobs:
     name: Orca Container Image Scan
     runs-on: ubuntu-latest
     permissions:
-        security-events: write
+      id-token: write
+      contents: write
+      pull-requests: write
+      security-events: write  
     env:
       PROJECT_KEY: observeinc-aws-sam-apps
       IMAGE_NAME: aws-sam-apps-all-binaries
@@ -54,6 +57,17 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+      
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN_ENG }} #Use Eng OIDC trusted role 
+          role-session-name: ${{ github.sha }}
+          aws-region: us-west-2
+
+      - name: Log in to Amazon ECR
+        if: github.ref_name == 'main'
+        uses: aws-actions/amazon-ecr-login@v2
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -63,8 +77,15 @@ jobs:
       - name: Build Docker Image Locally
         run: | 
             make docker-build-all-binaries-image IMAGE_NAME=${{ env.IMAGE_NAME }}
+      
+      - name: Tag and Push Docker Image to ECR (main branch only) #Used for Orca ECR Scanning 
+        if: github.ref_name == 'main'
+        run: |
+          ECR_REPO="723346149663.dkr.ecr.us-west-2.amazonaws.com/aws-sam-apps-orca"
+          docker tag ${{ env.IMAGE_NAME }}:latest $ECR_REPO:latest
+          docker push $ECR_REPO:latest
 
-      - name: Run Orca Container Image Scan
+      - name: Run Orca Container Image Scan #Used for CI Level Scanning (no alerts generated)
         uses: orcasecurity/shiftleft-container-image-action@v1
         with:
           api_token: ${{ secrets.ORCA_SECURITY_API_TOKEN }}


### PR DESCRIPTION
- Allows pushing of key `aws-sam-apps` binary image to ECR for Orca scanning 
- See comment: https://observe.atlassian.net/browse/CS-2416?focusedCommentId=266495 