### PR TITLE
chore: orca workflow on push to main

### DIFF
--- a/.github/workflows/orca.yaml
+++ b/.github/workflows/orca.yaml
@@ -42,6 +42,7 @@ jobs:
 
   orca-container-scan:
     name: Orca Container Image Scan
+    if: github.event_name == 'push' && github.ref_name == 'main' 
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -66,7 +67,6 @@ jobs:
           aws-region: us-west-2
 
       - name: Log in to Amazon ECR
-        if: github.ref_name == 'main'
         uses: aws-actions/amazon-ecr-login@v2
 
       - name: Set up Go
@@ -79,7 +79,6 @@ jobs:
             make docker-build-all-binaries-image IMAGE_NAME=${{ env.IMAGE_NAME }}
       
       - name: Tag and Push Docker Image to ECR (main branch only) #Used for Orca ECR Scanning 
-        if: github.ref_name == 'main'
         run: |
           ECR_REPO="723346149663.dkr.ecr.us-west-2.amazonaws.com/aws-sam-apps-orca"
           docker tag ${{ env.IMAGE_NAME }}:latest $ECR_REPO:latest


### PR DESCRIPTION
- Change workflow for container scan to only run on pushes to main
- Pushes to main should create a new "release" of docker image which is what we want scanned. 
- Currently the sha256 changes upon every single run of the same branch (no code or binary changes). 
- Because of above, running this on a schedule causes the docker image SHA to change in ECR (which deletes the old asset and it's alerts) 

Problematic asset override:
<img width="1201" alt="Screenshot 2025-05-19 at 4 54 02 PM" src="https://github.com/user-attachments/assets/82f9b5b5-0c18-4731-8a1d-65e3fb4c7fe2" />

