### PR TITLE
chore: update orca workflow to support image caching for SHA reproducibility

### DIFF
--- a/.github/workflows/orca.yaml
+++ b/.github/workflows/orca.yaml
@@ -52,13 +52,32 @@ jobs:
     env:
       PROJECT_KEY: observeinc-aws-sam-apps
       IMAGE_NAME: aws-sam-apps-all-binaries
+      VERSION: ${{ github.ref_name }}
+
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      
+        with:
+          driver-opts: image=moby/buildkit:latest
+          buildkitd-flags: --debug 
+
+      - name: Restore Docker cache
+        uses: actions/cache@v4
+        with:
+          path: .buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.ref }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-${{ github.ref }}-
+            ${{ runner.os }}-buildx-
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.23.8
+
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -67,22 +86,19 @@ jobs:
           aws-region: us-west-2
 
       - name: Log in to Amazon ECR
-        uses: aws-actions/amazon-ecr-login@v2
+        uses: aws-actions/amazon-ecr-login@v2  
 
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: 1.23.8
 
-      - name: Build Docker Image Locally
-        run: | 
-            make docker-build-all-binaries-image IMAGE_NAME=${{ env.IMAGE_NAME }}
-      
-      - name: Tag and Push Docker Image to ECR (main branch only) #Used for Orca ECR Scanning 
+      - name: Run push-to-ecr script
         run: |
-          ECR_REPO="723346149663.dkr.ecr.us-west-2.amazonaws.com/aws-sam-apps-orca"
-          docker tag ${{ env.IMAGE_NAME }}:latest $ECR_REPO:latest
-          docker push $ECR_REPO:latest
+          chmod +x push-to-ecr.sh
+          ./push-to-ecr.sh
+
+      - name: Save updated Docker cache
+        uses: actions/cache@v4
+        with:
+          path: .buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.ref }}-${{ github.sha }}
 
       - name: Run Orca Container Image Scan #Used for CI Level Scanning (no alerts generated)
         uses: orcasecurity/shiftleft-container-image-action@v1

--- a/Dockerfile.all-binaries
+++ b/Dockerfile.all-binaries
@@ -1,5 +1,7 @@
 # Dockerfile used for Orca scanning 
-FROM alpine:3.19
+
+#alpine:3.19.0
+FROM alpine@sha256:51b67269f354137895d43f3b3d810bfacd3945438e94dc5ac55fdac340352f48
 
 ARG OS
 ARG ARCH

--- a/push-to-ecr.sh
+++ b/push-to-ecr.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# ---- CONFIG ----
+IMAGE_NAME="${IMAGE_NAME:-aws-sam-apps-all-binaries}"  # Allow override via env
+AWS_REGION="${AWS_REGION:-us-west-2}"
+ECR_REPO="${ECR_REPO:-723346149663.dkr.ecr.us-west-2.amazonaws.com/aws-sam-apps-orca}"
+VERSION="${VERSION:-$(git rev-parse --abbrev-ref HEAD)}"
+OS="${OS:-linux}"
+ARCH="${ARCH:-arm64}"
+
+echo "🧮 Using:"
+echo "  IMAGE_NAME = $IMAGE_NAME"
+echo "  VERSION    = $VERSION"
+echo "  OS/ARCH    = $OS/$ARCH"
+echo "  ECR_REPO   = $ECR_REPO"
+
+# ---- BUILD IMAGE USING MAKE ----
+echo "🔧 Building Docker image using Make..."
+make docker-build-all-binaries-image IMAGE_NAME=$IMAGE_NAME OS=$OS ARCH=$ARCH VERSION=$VERSION
+
+# ---- LOGIN TO ECR ----
+echo "🔐 Logging into ECR..."
+aws ecr get-login-password --region "$AWS_REGION" | \
+  docker login --username AWS --password-stdin "$ECR_REPO"
+
+# ---- TAG IMAGE ----
+echo "🏷️ Tagging image..."
+docker tag "$IMAGE_NAME:latest" "$ECR_REPO:latest"
+
+# ---- PUSH IMAGE ----
+echo "📦 Pushing image to ECR..."
+docker push "$ECR_REPO:latest"
+
+# ----  Print final digest ----
+echo "🔍 Final image digest:"
+docker inspect --format='{{index .RepoDigests 0}}' "$ECR_REPO:latest" || echo "Digest not available yet"
+
+echo "✅ Done. Image pushed as: $ECR_REPO:latest"


### PR DESCRIPTION
Followup from this PR: https://github.com/observeinc/aws-sam-apps/pull/394

and addresses this ticket correctly: https://observe.atlassian.net/browse/OB-45637


Tested to use cache correctly and not override previous ECR images! 

Pinned to 12:44pm even though we have pushed many times. This is what orca requires for consistent scanning and to avoid redundant alert generations.

<img width="1261" alt="Screenshot 2025-05-20 at 12 52 54 PM" src="https://github.com/user-attachments/assets/0fd9f5d2-b234-4c08-8825-3b54a0224272" />

