### PR TITLE
chore: separate out orca workflows

### DIFF
--- a/.github/workflows/orca-ecr-release.yaml
+++ b/.github/workflows/orca-ecr-release.yaml
@@ -1,7 +1,7 @@
 name: Release Image to ECR 
 on:
   push:
-    #branches: ["main"]
+    branches: ["main"]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/orca-ecr-release.yaml
+++ b/.github/workflows/orca-ecr-release.yaml
@@ -1,4 +1,5 @@
-name: Release Image to ECR 
+name: Release Image to ECR for Orca Scanning
+
 on:
   push:
     branches: ["main"]

--- a/.github/workflows/orca-ecr-release.yaml
+++ b/.github/workflows/orca-ecr-release.yaml
@@ -1,0 +1,67 @@
+name: Release Image to ECR 
+on:
+  push:
+    #branches: ["main"]
+  workflow_dispatch:
+
+jobs:
+  push-orca-ecr:
+    name: Push aws-sam-apps image to ECR 
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+      pull-requests: write
+      security-events: write  
+    env:
+      PROJECT_KEY: observeinc-aws-sam-apps
+      IMAGE_NAME: aws-sam-apps-all-binaries
+      VERSION: ${{ github.ref_name }}
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: image=moby/buildkit:latest
+          buildkitd-flags: --debug 
+
+      - name: Restore Docker cache
+        if: always()
+        uses: actions/cache@v4
+        with:
+          path: .buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.ref }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-${{ github.ref }}-
+            ${{ runner.os }}-buildx-
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.23.8
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN_ENG }} #Use Eng OIDC trusted role 
+          role-session-name: ${{ github.sha }}
+          aws-region: us-west-2
+
+      - name: Log in to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v2  
+
+      - name: Run push-to-ecr script
+        run: |
+          chmod +x push-to-ecr.sh
+          ./push-to-ecr.sh
+
+      - name: Save updated Docker cache
+        if: always()
+        uses: actions/cache@v4
+        with:
+          path: .buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.ref }}-${{ github.sha }}
+          

--- a/.github/workflows/orca.yaml
+++ b/.github/workflows/orca.yaml
@@ -42,67 +42,29 @@ jobs:
 
   orca-container-scan:
     name: Orca Container Image Scan
-    if: github.event_name == 'push' && github.ref_name == 'main' 
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
-      contents: write
-      pull-requests: write
-      security-events: write  
+        security-events: write
     env:
       PROJECT_KEY: observeinc-aws-sam-apps
       IMAGE_NAME: aws-sam-apps-all-binaries
-      VERSION: ${{ github.ref_name }}
-
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-        with:
-          driver-opts: image=moby/buildkit:latest
-          buildkitd-flags: --debug 
-
-      - name: Restore Docker cache
-        if: always()
-        uses: actions/cache@v4
-        with:
-          path: .buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.ref }}-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-${{ github.ref }}-
-            ${{ runner.os }}-buildx-
 
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version: 1.23.8
 
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN_ENG }} #Use Eng OIDC trusted role 
-          role-session-name: ${{ github.sha }}
-          aws-region: us-west-2
+      - name: Build Docker Image Locally
+        run: | 
+            make docker-build-all-binaries-image IMAGE_NAME=${{ env.IMAGE_NAME }}
 
-      - name: Log in to Amazon ECR
-        uses: aws-actions/amazon-ecr-login@v2  
-
-
-      - name: Run push-to-ecr script
-        run: |
-          chmod +x push-to-ecr.sh
-          ./push-to-ecr.sh
-
-      - name: Save updated Docker cache
-        if: always()
-        uses: actions/cache@v4
-        with:
-          path: .buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.ref }}-${{ github.sha }}
-
-      - name: Run Orca Container Image Scan #Used for CI Level Scanning (no alerts generated)
+      - name: Run Orca Container Image Scan
         uses: orcasecurity/shiftleft-container-image-action@v1
         with:
           api_token: ${{ secrets.ORCA_SECURITY_API_TOKEN }}


### PR DESCRIPTION
- Caching doesn't work properly if workflow fails (regardless of forced github action steps)
- Separating out orca scan from ECR image push (so failure of scan doesn't affect caching steps)

We need:

```
Post job cleanup.
/usr/bin/tar --posix -cf cache.tzst --exclude cache.tzst -P -C /home/runner/work/aws-sam-apps/aws-sam-apps --files-from manifest.txt --use-compress-program zstdmt
Sent 38310[2](https://github.com/observeinc/aws-sam-apps/actions/runs/15147503667/job/42586651974#step:12:2)50 of 38310250 (100.0%), 41.1 MBs/sec
Cache saved with key: Linux-buildx-refs/heads/nikhil/separate-image-build-steps-146bac5b614ce854162a0894c4c6b53fe937880e
``` 

See example of failures (post-docker save cache step doesn't register)

<img width="843" alt="Screenshot 2025-05-20 at 1 49 55 PM" src="https://github.com/user-attachments/assets/5819f501-fc8b-478c-9934-a4a9ef9b72f4" />

