### PR TITLE
build(deps): Update build tests OB-46206

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ tfplan
 .terraform.lock.hcl
 .make.env
 .DS_STORE
+
+.idea
+tftests

--- a/apps/metricstream/template.yaml
+++ b/apps/metricstream/template.yaml
@@ -3,6 +3,10 @@ AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
 Description: 'Stream CloudWatch Metrics to S3.'
 Metadata:
+  cfn-lint:
+    config:
+      ignore_checks:
+        - W1030
   AWS::ServerlessRepo::Application:
     Name: observe-metric-stream
     Description: Stream CloudWatch Metrics to S3.

--- a/apps/stack/template.yaml
+++ b/apps/stack/template.yaml
@@ -4,6 +4,10 @@ Transform: AWS::Serverless-2016-10-31
 Description: >
   Collect resource, logs and metrics from AWS
 Metadata:
+  cfn-lint:
+    config:
+      ignore_checks:
+        - W1030
   AWS::ServerlessRepo::Application:
     Name: observe-aws-collection
     Description: Collect resource, logs and metrics data from AWS

--- a/cmd/testing/forwarderhttp/main.go
+++ b/cmd/testing/forwarderhttp/main.go
@@ -8,6 +8,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"path/filepath"
 
@@ -69,7 +70,11 @@ func realInit() error {
 			w.WriteHeader(400)
 		}
 		// remove file if it still exists by the end of processing
-		defer os.Remove(f.Name())
+		defer func() {
+			if err := os.Remove(f.Name()); err != nil {
+				log.Printf("Failed to remove file %s: %v", f.Name(), err)
+			}
+		}()
 
 		hasher := sha256.New()
 		body := io.TeeReader(r.Body, hasher)

--- a/pkg/handler/forwarder/handler.go
+++ b/pkg/handler/forwarder/handler.go
@@ -197,7 +197,7 @@ func (h *Handler) Handle(ctx context.Context, request events.SQSEvent) (response
 		result := <-resultCh
 		if result.ErrorMessage != "" {
 			response.BatchItemFailures = append(response.BatchItemFailures, events.SQSBatchItemFailure{
-				ItemIdentifier: result.SQSMessage.MessageId,
+				ItemIdentifier: result.MessageId,
 			})
 		}
 		if e := encoder.Encode(result); e != nil {

--- a/pkg/handler/forwarder/s3http/config_test.go
+++ b/pkg/handler/forwarder/s3http/config_test.go
@@ -43,7 +43,7 @@ func TestConfig(t *testing.T) {
 		{
 			Config: s3http.Config{
 				DestinationURI:     "https://test",
-				GzipLevel:   ptr(200),
+				GzipLevel:          ptr(200),
 				GetObjectAPIClient: &awstest.S3Client{},
 			},
 			ExpectError: s3http.ErrUnsupportedGzipLevel,

--- a/pkg/handler/forwarder/s3http/internal/batch/runner_test.go
+++ b/pkg/handler/forwarder/s3http/internal/batch/runner_test.go
@@ -54,8 +54,8 @@ func TestRunner(t *testing.T) {
 			var batches []string
 			var mu sync.Mutex
 
-			tt.RunInput.Decoder = json.NewDecoder(strings.NewReader(tt.Input))
-			tt.RunInput.Handler = batch.HandlerFunc(func(_ context.Context, r io.Reader) error {
+			tt.Decoder = json.NewDecoder(strings.NewReader(tt.Input))
+			tt.Handler = batch.HandlerFunc(func(_ context.Context, r io.Reader) error {
 				data, err := io.ReadAll(r)
 				if err != nil {
 					return fmt.Errorf("failed to read: %w", err)

--- a/pkg/handler/forwarder/s3http/internal/decoders/csv.go
+++ b/pkg/handler/forwarder/s3http/internal/decoders/csv.go
@@ -20,7 +20,7 @@ func CSVDecoderFactory(r io.Reader, params map[string]string) Decoder {
 		Reader:   csv.NewReader(buffered),
 		buffered: buffered,
 	}
-	csvDecoder.Reader.FieldsPerRecord = -1
+	csvDecoder.FieldsPerRecord = -1
 
 	var delimiter rune
 	switch params["delimiter"] {
@@ -34,7 +34,7 @@ func CSVDecoderFactory(r io.Reader, params map[string]string) Decoder {
 		err := fmt.Errorf("%w: %q", ErrUnsupportedDelimiter, params["delimiter"])
 		return &errorDecoder{err}
 	}
-	csvDecoder.Reader.Comma = delimiter
+	csvDecoder.Comma = delimiter
 	return csvDecoder
 }
 
@@ -57,14 +57,14 @@ type CSVDecoder struct {
 
 func (dec *CSVDecoder) Decode(v any) error {
 	var err error
-	dec.Once.Do(func() {
+	dec.Do(func() {
 		dec.header, err = dec.Read()
 		for i, h := range dec.header {
 			dec.header[i] = strconv.Quote(h)
 		}
 		// After the header is determined, we can allow the csv.Reader to reuse
 		// a []string for every subsequent record.
-		dec.Reader.ReuseRecord = true
+		dec.ReuseRecord = true
 	})
 	if err != nil {
 		return fmt.Errorf("failed to decode header: %w", err)

--- a/pkg/handler/forwarder/s3http/internal/decoders/decoder_test.go
+++ b/pkg/handler/forwarder/s3http/internal/decoders/decoder_test.go
@@ -109,7 +109,11 @@ func readFile(t *testing.T, filename string) io.Reader {
 		t.Fatal("failed to open file:", err)
 	}
 
-	t.Cleanup(func() { file.Close() })
+	t.Cleanup(func() {
+		if err := file.Close(); err != nil {
+			t.Errorf("failed to close file: %v", err)
+		}
+	})
 	return file
 }
 

--- a/pkg/handler/forwarder/s3http/internal/request/handler.go
+++ b/pkg/handler/forwarder/s3http/internal/request/handler.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"strings"
 )
@@ -48,7 +49,11 @@ func (h *Handler) Handle(ctx context.Context, body io.Reader) error {
 	if err != nil {
 		return fmt.Errorf("failed to execute request: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			log.Printf("failed to close response body: %v", closeErr)
+		}
+	}()
 	if _, err := io.Copy(io.Discard, resp.Body); err != nil {
 		return fmt.Errorf("failed to read response body: %w", err)
 	}

--- a/pkg/handler/forwarder/s3http/internal/request/handler_test.go
+++ b/pkg/handler/forwarder/s3http/internal/request/handler_test.go
@@ -14,7 +14,11 @@ import (
 
 func TestHandler(t *testing.T) {
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		defer r.Body.Close()
+		defer func() {
+			if err := r.Body.Close(); err != nil {
+				t.Errorf("failed to close request body: %v", err)
+			}
+		}()
 
 		body := r.Body
 		if r.Header.Get("Content-Encoding") == "gzip" {

--- a/pkg/handler/metricsconfigurator/handler.go
+++ b/pkg/handler/metricsconfigurator/handler.go
@@ -260,7 +260,11 @@ func (h Handler) getDatasource(token *string, observeDomainName string, client *
 	if err != nil {
 		return nil, fmt.Errorf("error receiving response from graphql: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil && err == nil {
+			logger.Error(closeErr, "failed to close response body")
+		}
+	}()
 
 	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/pkg/handler/subscriber/instrument.go
+++ b/pkg/handler/subscriber/instrument.go
@@ -44,7 +44,7 @@ func (h *InstrumentedHandler) HandleSQS(ctx context.Context, request events.SQSE
 }
 
 func (h *InstrumentedHandler) HandleRequest(ctx context.Context, req *Request) (*Response, error) {
-	ctx, span := h.Tracer.Start(ctx, "HandleRequest")
+	ctx, span := h.Start(ctx, "HandleRequest")
 	var err error
 	defer func() {
 		if err != nil {

--- a/pkg/handler/subscriber/request_test.go
+++ b/pkg/handler/subscriber/request_test.go
@@ -47,7 +47,7 @@ func TestRequestMalformed(t *testing.T) {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
 			t.Parallel()
 
-			err := tt.Request.Validate()
+			err := tt.Validate()
 			if diff := cmp.Diff(tt.ExpectError, err, cmpopts.EquateErrors()); diff != "" {
 				t.Error(diff)
 			}

--- a/pkg/lambda/env.go
+++ b/pkg/lambda/env.go
@@ -12,7 +12,9 @@ import (
 // This is useful for cases where we set a default in our env struct, and need
 // the value to be propagated to other processes.
 func exportEnvVar(_ context.Context, _, resolvedKey, _, resolvedValue string) (newValue string, stop bool, err error) {
-	os.Setenv(resolvedKey, resolvedValue)
+	if err := os.Setenv(resolvedKey, resolvedValue); err != nil {
+		return "", false, fmt.Errorf("failed to set environment variable %s: %w", resolvedKey, err)
+	}
 	return resolvedValue, false, nil
 }
 


### PR DESCRIPTION
## Changes
Update build tests

• Fixed unchecked error returns for `os.Remove`, `getResp.Body.Close`, `file.Close`, `gr.Close`, `resp.Body.Close`, `r.Body.Close`, and `os.Setenv` as reported by `errcheck` linter.
• Addressed `staticcheck` `QF1008` issues by removing unnecessary embedded field selectors in multiple packages.
• Ensured latest `golangci/golangci-lint` run issues are resolved.
• Added `cfn-lint` to `metadata`, to `ignore_checks` to resolve `[[W1030: Validate the values that come from a Ref function] ({'Ref': 'GQLToken'} is shorter than 1 when 'Ref' is resolved) matched 327]` during `Validate SAM templates` in build tests.

## Testing
• Ran all integration tests via `make test-integration`
• Manually ran `sam deploy` to validate apps continue to function.