### PR TITLE
build(deps): Update Go version to 1.24.6 - OB-48697

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/observeinc/aws-sam-apps
 
-go 1.24.4
+go 1.24.6
 
 require (
 	github.com/aws/aws-lambda-go v1.47.0

--- a/variables.mk
+++ b/variables.mk
@@ -37,7 +37,7 @@ GO_BUILD_DIRS   := bin/$(OS)_$(ARCH)                   \
                 .go/cache                           \
                 .go/pkg
 # Build image to use for building lambda functions
-GO_BUILD_IMAGE  ?= golang:1.24.4-alpine
+GO_BUILD_IMAGE  ?= golang:1.24.6-alpine
 # Which Go modules mode to use ("mod" or "vendor")
 GO_MOD          ?= vendor
 GOFLAGS         ?=


### PR DESCRIPTION
Changes
• Updated Go version in go.mod to `1.24.6`
• Ran go mod tidy and go mod vendor to sync dependencies
• Updated Docker image to `golang:1.24.6-alpine`

Testing
• Verified builds pass with Go `1.24.6`
• Ran all integration tests via `make test-integration`