### PR TITLE
build: add SKIP_REGIONS to allow skipping unavailable regions during …

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,6 +11,10 @@ on:
         type: boolean
         description: 'Skip tests.'
         default: false
+      skip_regions:
+        type: string
+        description: 'Space-separated list of regions to skip'
+        default: ''
  
 jobs:
   version:
@@ -52,6 +56,7 @@ jobs:
       s3_bucket_prefix: "observeinc-"
       global: ${{ needs.version.outputs.version != '' }}
       release_version: ${{ needs.version.outputs.version }}
+      skip_regions: ${{ inputs.skip_regions }}
 
   integration:
     needs: upload

--- a/.github/workflows/upload.yaml
+++ b/.github/workflows/upload.yaml
@@ -19,6 +19,10 @@ on:
         type: string
         description: 'Release version to use. If omitted, version will be computed'
         default: ''
+      skip_regions:
+        type: string
+        description: 'Space-separated list of regions to skip'
+        default: ''
     outputs:
       release_version:
         description: "Release version used."
@@ -65,3 +69,4 @@ jobs:
         MAKEFLAGS: "-j ${{ inputs.concurrency }} --output-sync=target"
         S3_BUCKET_PREFIX: "${{ inputs.s3_bucket_prefix }}"
         RELEASE_VERSION: "${{ inputs.release_version }}"
+        SKIP_REGIONS: "${{ inputs.skip_regions }}"

--- a/variables.mk
+++ b/variables.mk
@@ -4,8 +4,12 @@ APPS         := $(shell find apps/* -type d -maxdepth 0 -exec basename {} \;)
 # This is our default region when not provided.
 AWS_REGION   ?= us-west-2
 
+# Regions to skip (set via environment to exclude broken/unavailable regions).
+SKIP_REGIONS ?=
+
 # List of regions supported by `make sam-push-*`.
-AWS_REGIONS  := us-west-2      \
+AWS_REGIONS  := $(filter-out $(SKIP_REGIONS), \
+                us-west-2      \
                 us-west-1      \
                 us-east-2      \
                 us-east-1      \
@@ -26,7 +30,7 @@ AWS_REGIONS  := us-west-2      \
                 me-south-1 \
                 me-central-1 \
                 il-central-1 \
-                mx-central-1 \
+                mx-central-1)
 
 # Assume lambda functions are linux/arm64
 # These variables must be defined before GO_BUILD_DIRS


### PR DESCRIPTION
…release

Adds a SKIP_REGIONS variable (defaulting to empty) that filters regions out of AWS_REGIONS via make's filter-out. Exposed as a workflow_dispatch input on the Release workflow so broken regions can be skipped without code changes.

Made-with: Cursor