### PR TITLE
feat: Update Tag release to allow SKIP_REGIONS

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -90,7 +90,7 @@ jobs:
     - name: AWS Info
       run: aws sts get-caller-identity
 
-    - name: Tag release 
+    - name: Tag release
       id: build
       run: |
           make tag
@@ -99,6 +99,7 @@ jobs:
         S3_BUCKET_PREFIX: "observeinc-"
         RELEASE_VERSION: "${{ needs.version.outputs.version }}"
         RELEASE_TAG: ${{ needs.version.outputs.channel }}
+        SKIP_REGIONS: "${{ inputs.skip_regions }}"
 
     - name: Cut release
       id: release


### PR DESCRIPTION
## Problem

The release workflow was failing during the publish step when attempting to pull SAM manifests from the `me-south-1` region, which is currently experiencing availability issues.

The workflow's `upload` step correctly respected the `skip_regions` input parameter, but the `publish` step (which runs `make tag`) did not pass the `SKIP_REGIONS` environment variable, causing it to attempt operations on all regions including unavailable ones.

Note: Fix updated using Augment