### PR TITLE
fix(forwarder): URL-encode S3 CopySource for x-amz-copy-source

### DIFF
--- a/pkg/handler/forwarder/handler.go
+++ b/pkg/handler/forwarder/handler.go
@@ -50,6 +50,35 @@ type Handler struct {
 	MaxConcurrentTasks int
 }
 
+// encodeS3CopySourceKey URL-encodes each path segment for x-amz-copy-source (S3 requires
+// an encoded key; unescaped '+' is treated as space in headers).
+func encodeS3CopySourceKey(key string) string {
+	key = strings.TrimPrefix(key, "/")
+	if key == "" {
+		return ""
+	}
+	segs := strings.Split(key, "/")
+	for i := range segs {
+		segs[i] = url.PathEscape(segs[i])
+	}
+	// PathEscape leaves '+' literal; S3 copy-source headers treat '+' as space.
+	return strings.ReplaceAll(strings.Join(segs, "/"), "+", "%2B")
+}
+
+// unencodedCopySourceForPolicy reverses CopySource encoding from GetCopyObjectInput so
+// ObjectPolicy (glob) patterns still match the original bucket/key form.
+func unencodedCopySourceForPolicy(encoded string) string {
+	parts := strings.SplitN(encoded, "/", 2)
+	if len(parts) != 2 {
+		return encoded
+	}
+	k, err := url.PathUnescape(parts[1])
+	if err != nil {
+		return encoded
+	}
+	return parts[0] + "/" + k
+}
+
 // GetCopyObjectInput constructs the input struct for CopyObject.
 func GetCopyObjectInput(source, destination *url.URL) *s3.CopyObjectInput {
 	if source == nil || destination == nil {
@@ -58,7 +87,7 @@ func GetCopyObjectInput(source, destination *url.URL) *s3.CopyObjectInput {
 
 	var (
 		bucket     = destination.Host
-		copySource = fmt.Sprintf("%s%s", source.Host, source.Path)
+		copySource = fmt.Sprintf("%s/%s", source.Host, encodeS3CopySourceKey(strings.TrimPrefix(source.Path, "/")))
 		key        = source.Path
 	)
 
@@ -147,7 +176,7 @@ func (h *Handler) ProcessRecord(ctx context.Context, record *events.SQSMessage) 
 
 		copyInput := GetCopyObjectInput(sourceURL, h.DestinationURI)
 
-		if !h.ObjectPolicy.Allow(aws.ToString(copyInput.CopySource)) {
+		if !h.ObjectPolicy.Allow(unencodedCopySourceForPolicy(aws.ToString(copyInput.CopySource))) {
 			logger.Info("Ignoring object not in allowed sources", "bucket", copyInput.Bucket, "key", copyInput.Key)
 			continue
 		}

--- a/pkg/handler/forwarder/handler_test.go
+++ b/pkg/handler/forwarder/handler_test.go
@@ -82,6 +82,16 @@ func TestCopy(t *testing.T) {
 				Key:        aws.String("hello/test.json"),
 			},
 		},
+		{
+			// '+' in object key must appear as %2B in CopySource (S3 x-amz-copy-source).
+			SourceURI:      "s3://example-source-bucket/2026-04-08T20:50:00+00:00.json",
+			DestinationURI: "s3://another-bucket",
+			Expected: &s3.CopyObjectInput{
+				Bucket:     aws.String("another-bucket"),
+				CopySource: aws.String("example-source-bucket/2026-04-08T20:50:00%2B00:00.json"),
+				Key:        aws.String("2026-04-08T20:50:00+00:00.json"),
+			},
+		},
 	}
 
 	for i, tc := range testcases {

--- a/pkg/handler/forwarder/override/rule.go
+++ b/pkg/handler/forwarder/override/rule.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/url"
 	"reflect"
 	"regexp"
 	"strings"
@@ -27,10 +28,25 @@ type Filter struct {
 	ContentEncoding *regexp.Regexp `mapstructure:"content-encoding"`
 }
 
+func copySourceForRegexMatch(copySource string) string {
+	parts := strings.SplitN(copySource, "/", 2)
+	if len(parts) != 2 {
+		return copySource
+	}
+	k, err := url.PathUnescape(parts[1])
+	if err != nil {
+		return copySource
+	}
+	return parts[0] + "/" + k
+}
+
 // Match input object.
 func (f *Filter) Match(input *s3.CopyObjectInput) bool {
-	if f.Source != nil && !f.Source.MatchString(aws.ToString(input.CopySource)) {
-		return false
+	if f.Source != nil {
+		cs := aws.ToString(input.CopySource)
+		if !f.Source.MatchString(cs) && !f.Source.MatchString(copySourceForRegexMatch(cs)) {
+			return false
+		}
 	}
 	if f.ContentType != nil && !f.ContentType.MatchString(aws.ToString(input.ContentType)) {
 		return false

--- a/pkg/handler/forwarder/s3http/client.go
+++ b/pkg/handler/forwarder/s3http/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/url"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -43,9 +44,14 @@ func toGetInput(copyInput *s3.CopyObjectInput) (*s3.GetObjectInput, error) {
 		return nil, fmt.Errorf("%w: %q", errInvalidCopySource, aws.ToString(copyInput.CopySource))
 	}
 
+	rawKey, err := url.PathUnescape(parts[1])
+	if err != nil {
+		rawKey = parts[1]
+	}
+
 	return &s3.GetObjectInput{
 		Bucket:               aws.String(parts[0]),
-		Key:                  aws.String(parts[1]),
+		Key:                  aws.String(rawKey),
 		ExpectedBucketOwner:  copyInput.ExpectedSourceBucketOwner,
 		IfMatch:              copyInput.CopySourceIfMatch,
 		IfModifiedSince:      copyInput.CopySourceIfModifiedSince,


### PR DESCRIPTION
Path-escape object key segments, encode '+' as '%2B', keep unencoded form for source filters, decode in s3http Get shim and match override regexes against encoded or decoded CopySource.

Made-with: Cursor