### PR TITLE
fix(forwarder): encode '+' as '%2B' in CopySource for x-amz-copy-source

### DIFF
--- a/pkg/handler/forwarder/handler.go
+++ b/pkg/handler/forwarder/handler.go
@@ -50,6 +50,17 @@ type Handler struct {
 	MaxConcurrentTasks int
 }
 
+// encodeCopySourceKey URL-encodes each path segment of an S3 key for use in
+// the x-amz-copy-source header, preserving '/' separators between segments.
+func encodeCopySourceKey(rawKey string) string {
+	rawKey = strings.TrimPrefix(rawKey, "/")
+	segs := strings.Split(rawKey, "/")
+	for i := range segs {
+		segs[i] = url.QueryEscape(segs[i])
+	}
+	return strings.Join(segs, "/")
+}
+
 // GetCopyObjectInput constructs the input struct for CopyObject.
 func GetCopyObjectInput(source, destination *url.URL) *s3.CopyObjectInput {
 	if source == nil || destination == nil {
@@ -58,7 +69,7 @@ func GetCopyObjectInput(source, destination *url.URL) *s3.CopyObjectInput {
 
 	var (
 		bucket     = destination.Host
-		copySource = fmt.Sprintf("%s%s", source.Host, source.Path)
+		copySource = source.Host + "/" + encodeCopySourceKey(source.Path)
 		key        = source.Path
 	)
 
@@ -147,7 +158,7 @@ func (h *Handler) ProcessRecord(ctx context.Context, record *events.SQSMessage) 
 
 		copyInput := GetCopyObjectInput(sourceURL, h.DestinationURI)
 
-		if !h.ObjectPolicy.Allow(aws.ToString(copyInput.CopySource)) {
+		if !h.ObjectPolicy.Allow(sourceURL.Host + sourceURL.Path) {
 			logger.Info("Ignoring object not in allowed sources", "bucket", copyInput.Bucket, "key", copyInput.Key)
 			continue
 		}

--- a/pkg/handler/forwarder/handler_test.go
+++ b/pkg/handler/forwarder/handler_test.go
@@ -82,6 +82,15 @@ func TestCopy(t *testing.T) {
 				Key:        aws.String("hello/test.json"),
 			},
 		},
+		{
+			SourceURI:      "s3://example-bucket/2026-04-08T20:50:00+00:00.json",
+			DestinationURI: "s3://another-bucket",
+			Expected: &s3.CopyObjectInput{
+				Bucket:     aws.String("another-bucket"),
+				CopySource: aws.String("example-bucket/2026-04-08T20%3A50%3A00%2B00%3A00.json"),
+				Key:        aws.String("2026-04-08T20:50:00+00:00.json"),
+			},
+		},
 	}
 
 	for i, tc := range testcases {

--- a/pkg/handler/forwarder/override/rule.go
+++ b/pkg/handler/forwarder/override/rule.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/url"
 	"reflect"
 	"regexp"
 	"strings"
@@ -29,8 +30,11 @@ type Filter struct {
 
 // Match input object.
 func (f *Filter) Match(input *s3.CopyObjectInput) bool {
-	if f.Source != nil && !f.Source.MatchString(aws.ToString(input.CopySource)) {
-		return false
+	if f.Source != nil {
+		cs, _ := url.QueryUnescape(aws.ToString(input.CopySource))
+		if !f.Source.MatchString(cs) {
+			return false
+		}
 	}
 	if f.ContentType != nil && !f.ContentType.MatchString(aws.ToString(input.ContentType)) {
 		return false

--- a/pkg/handler/forwarder/s3http/client.go
+++ b/pkg/handler/forwarder/s3http/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/url"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -37,6 +38,13 @@ type Client struct {
 	GzipLevel      *int
 }
 
+func queryUnescapeOrOriginal(s string) string {
+	if v, err := url.QueryUnescape(s); err == nil {
+		return v
+	}
+	return s
+}
+
 func toGetInput(copyInput *s3.CopyObjectInput) (*s3.GetObjectInput, error) {
 	parts := strings.SplitN(aws.ToString(copyInput.CopySource), "/", 2)
 	if len(parts) != 2 {
@@ -45,7 +53,7 @@ func toGetInput(copyInput *s3.CopyObjectInput) (*s3.GetObjectInput, error) {
 
 	return &s3.GetObjectInput{
 		Bucket:               aws.String(parts[0]),
-		Key:                  aws.String(parts[1]),
+		Key:                  aws.String(queryUnescapeOrOriginal(parts[1])),
 		ExpectedBucketOwner:  copyInput.ExpectedSourceBucketOwner,
 		IfMatch:              copyInput.CopySourceIfMatch,
 		IfModifiedSince:      copyInput.CopySourceIfModifiedSince,


### PR DESCRIPTION
S3 treats unencoded '+' in copy-source headers as a space, causing NoSuchKey for keys containing '+'. Decode back to '+' for policy filters, override regex matching, and s3http GetObject key.

Made-with: Cursor