### PR TITLE
fix(cfn): remove invalid MemorySize 64 from forwarder (cfn-lint W1030)

### DIFF
--- a/apps/forwarder/template.yaml
+++ b/apps/forwarder/template.yaml
@@ -111,7 +111,6 @@ Parameters:
     Default: ''
     AllowedValues:
       - ''
-      - '64'
       - '128'
       - '256'
       - '512'


### PR DESCRIPTION
Lambda minimum memory is 128 MB; allowing 64 triggered cfn-lint W1030 when sam validate runs with lint enabled.

Made-with: Cursor