### PR TITLE
feat: add pollerconfigurator Lambda for managing Observe pollers

### DIFF
--- a/Dockerfile.all-binaries
+++ b/Dockerfile.all-binaries
@@ -11,8 +11,9 @@ ARG ARCH
 COPY .go/bin/${OS}_${ARCH}/forwarder /usr/local/bin/forwarder
 COPY .go/bin/${OS}_${ARCH}/subscriber /usr/local/bin/subscriber
 COPY .go/bin/${OS}_${ARCH}/metricsconfigurator /usr/local/bin/metricsconfigurator
+COPY .go/bin/${OS}_${ARCH}/pollerconfigurator /usr/local/bin/pollerconfigurator
 
-RUN chmod +x /usr/local/bin/forwarder /usr/local/bin/subscriber /usr/local/bin/metricsconfigurator
+RUN chmod +x /usr/local/bin/forwarder /usr/local/bin/subscriber /usr/local/bin/metricsconfigurator /usr/local/bin/pollerconfigurator
 
 # Optional: provide a default command or entrypoint
 ENTRYPOINT ["/bin/sh"]

--- a/cmd/pollerconfigurator/main.go
+++ b/cmd/pollerconfigurator/main.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	awslambda "github.com/aws/aws-lambda-go/lambda"
+
+	handler "github.com/observeinc/aws-sam-apps/pkg/handler/pollerconfigurator"
+	"github.com/observeinc/aws-sam-apps/pkg/lambda"
+	"github.com/observeinc/aws-sam-apps/pkg/lambda/pollerconfigurator"
+)
+
+var (
+	rec *pollerconfigurator.Lambda
+)
+
+func init() {
+	ctx := context.Background()
+
+	var config handler.Config
+	err := lambda.ProcessEnv(ctx, &config)
+	if err != nil {
+		panic(fmt.Errorf("failed to initialize config: %w", err))
+	}
+
+	rec, err = pollerconfigurator.New(ctx, &config)
+	if err != nil {
+		panic(fmt.Errorf("failed to configure entrypoint: %w", err))
+	}
+}
+
+func main() {
+	awslambda.StartWithOptions(rec.Entrypoint, awslambda.WithEnableSIGTERM(rec.Shutdown))
+}

--- a/pkg/handler/pollerconfigurator/config.go
+++ b/pkg/handler/pollerconfigurator/config.go
@@ -1,0 +1,15 @@
+package pollerconfigurator
+
+import "github.com/observeinc/aws-sam-apps/pkg/logging"
+
+type Config struct {
+	ObserveAccountID  string `env:"OBSERVE_ACCOUNT_ID,required"`
+	ObserveDomainName string `env:"OBSERVE_DOMAIN_NAME,required"`
+	SecretName        string `env:"SECRET_NAME,required"`
+	PollerConfigURI   string `env:"POLLER_CONFIG_URI,required"`
+	ExternalRoleName  string `env:"EXTERNAL_ROLE_NAME,required"`
+	WorkspaceID       string `env:"WORKSPACE_ID,required"`
+	Region            string `env:"AWS_REGION,required"`
+	AWSAccountID      string `env:"AWS_ACCOUNT_ID,required"`
+	Logging           *logging.Config
+}

--- a/pkg/handler/pollerconfigurator/gql.go
+++ b/pkg/handler/pollerconfigurator/gql.go
@@ -1,0 +1,259 @@
+package pollerconfigurator
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/go-logr/logr"
+)
+
+const bearerTokenFormat = "Bearer %s %s"
+
+type graphQLRequest struct {
+	Query string `json:"query"`
+}
+
+type createPollerResponse struct {
+	Data struct {
+		CreatePoller struct {
+			ID   string `json:"id"`
+			Name string `json:"name"`
+		} `json:"createPoller"`
+	} `json:"data"`
+	Errors []struct {
+		Message string `json:"message"`
+	} `json:"errors"`
+}
+
+type updatePollerResponse struct {
+	Data struct {
+		UpdatePoller struct {
+			ID   string `json:"id"`
+			Name string `json:"name"`
+		} `json:"updatePoller"`
+	} `json:"data"`
+	Errors []struct {
+		Message string `json:"message"`
+	} `json:"errors"`
+}
+
+type deletePollerResponse struct {
+	Data struct {
+		DeletePoller struct {
+			Success bool `json:"success"`
+		} `json:"deletePoller"`
+	} `json:"data"`
+	Errors []struct {
+		Message string `json:"message"`
+	} `json:"errors"`
+}
+
+func buildQueriesGQL(queries []QueryConfig) string {
+	var parts []string
+	for _, q := range queries {
+		var fields []string
+		fields = append(fields, fmt.Sprintf(`namespace: %q`, q.Namespace))
+
+		if len(q.MetricNames) > 0 {
+			names := make([]string, len(q.MetricNames))
+			for i, n := range q.MetricNames {
+				names[i] = fmt.Sprintf("%q", n)
+			}
+			fields = append(fields, fmt.Sprintf(`metricNames: [%s]`, strings.Join(names, ", ")))
+		}
+
+		if len(q.Dimensions) > 0 {
+			var dims []string
+			for _, d := range q.Dimensions {
+				if d.Value != "" {
+					dims = append(dims, fmt.Sprintf(`{name: %q, value: %q}`, d.Name, d.Value))
+				} else {
+					dims = append(dims, fmt.Sprintf(`{name: %q}`, d.Name))
+				}
+			}
+			fields = append(fields, fmt.Sprintf(`dimensions: [%s]`, strings.Join(dims, ", ")))
+		}
+
+		if q.ResourceFilter != nil {
+			rf := q.ResourceFilter
+			var rfFields []string
+			if rf.ResourceType != "" {
+				rfFields = append(rfFields, fmt.Sprintf(`resourceType: %q`, rf.ResourceType))
+			}
+			if rf.Pattern != "" {
+				rfFields = append(rfFields, fmt.Sprintf(`pattern: %q`, rf.Pattern))
+			}
+			if rf.DimensionName != "" {
+				rfFields = append(rfFields, fmt.Sprintf(`dimensionName: %q`, rf.DimensionName))
+			}
+			var tagParts []string
+			for _, tf := range rf.TagFilters {
+				if len(tf.Values) > 0 {
+					vals := make([]string, len(tf.Values))
+					for i, v := range tf.Values {
+						vals[i] = fmt.Sprintf("%q", v)
+					}
+					tagParts = append(tagParts, fmt.Sprintf(`{key: %q, values: [%s]}`, tf.Key, strings.Join(vals, ", ")))
+				} else {
+					tagParts = append(tagParts, fmt.Sprintf(`{key: %q}`, tf.Key))
+				}
+			}
+			rfFields = append(rfFields, fmt.Sprintf(`tagFilters: [%s]`, strings.Join(tagParts, ", ")))
+			fields = append(fields, fmt.Sprintf(`resourceFilter: {%s}`, strings.Join(rfFields, ", ")))
+		}
+
+		parts = append(parts, fmt.Sprintf(`{%s}`, strings.Join(fields, ", ")))
+	}
+	return fmt.Sprintf("[%s]", strings.Join(parts, ", "))
+}
+
+func buildPollerInputGQL(cfg *PollerConfig, region, assumeRoleArn string) string {
+	var fields []string
+	if cfg.Name != "" {
+		fields = append(fields, fmt.Sprintf(`name: %q`, cfg.Name))
+	}
+	if cfg.DatastreamId != "" {
+		fields = append(fields, fmt.Sprintf(`datastreamId: %q`, cfg.DatastreamId))
+	}
+	if cfg.Interval != "" {
+		fields = append(fields, fmt.Sprintf(`interval: %q`, cfg.Interval))
+	}
+	if cfg.Retries != nil {
+		fields = append(fields, fmt.Sprintf(`retries: "%d"`, *cfg.Retries))
+	}
+
+	cwFields := []string{
+		fmt.Sprintf(`period: "%d"`, cfg.Period),
+		fmt.Sprintf(`delay: "%d"`, cfg.Delay),
+		fmt.Sprintf(`region: %q`, region),
+		fmt.Sprintf(`assumeRoleArn: %q`, assumeRoleArn),
+		fmt.Sprintf(`queries: %s`, buildQueriesGQL(cfg.Queries)),
+	}
+
+	fields = append(fields, fmt.Sprintf(`cloudWatchMetricsConfig: {%s}`, strings.Join(cwFields, ", ")))
+	return fmt.Sprintf(`{%s}`, strings.Join(fields, ", "))
+}
+
+func buildCreatePollerMutation(workspaceID string, cfg *PollerConfig, region, assumeRoleArn string) string {
+	input := buildPollerInputGQL(cfg, region, assumeRoleArn)
+	return fmt.Sprintf(`mutation { createPoller(workspaceId: %q, poller: %s) { id name } }`, workspaceID, input)
+}
+
+func buildUpdatePollerMutation(pollerID string, cfg *PollerConfig, region, assumeRoleArn string) string {
+	input := buildPollerInputGQL(cfg, region, assumeRoleArn)
+	return fmt.Sprintf(`mutation { updatePoller(id: %q, poller: %s) { id name } }`, pollerID, input)
+}
+
+func buildDeletePollerMutation(pollerID string) string {
+	return fmt.Sprintf(`mutation { deletePoller(id: %q) { success } }`, pollerID)
+}
+
+type gqlClient struct {
+	httpClient        *http.Client
+	observeAccountID  string
+	observeDomainName string
+	logger            logr.Logger
+}
+
+func (c *gqlClient) execute(token, query string) ([]byte, error) {
+	fullToken := fmt.Sprintf(bearerTokenFormat, c.observeAccountID, token)
+
+	jsonData, err := json.Marshal(graphQLRequest{Query: query})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal GQL request: %w", err)
+	}
+
+	host := fmt.Sprintf("%s.%s", c.observeAccountID, c.observeDomainName)
+	url := fmt.Sprintf("https://%s/v1/meta", host)
+
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create HTTP request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", fullToken)
+
+	c.logger.V(4).Info("executing GQL request", "url", url)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("GQL request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read GQL response body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GQL request returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	return body, nil
+}
+
+func (c *gqlClient) createPoller(token, workspaceID string, cfg *PollerConfig, region, assumeRoleArn string) (string, error) {
+	query := buildCreatePollerMutation(workspaceID, cfg, region, assumeRoleArn)
+	body, err := c.execute(token, query)
+	if err != nil {
+		return "", err
+	}
+
+	var result createPollerResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		return "", fmt.Errorf("failed to parse createPoller response: %w", err)
+	}
+	if len(result.Errors) > 0 {
+		return "", fmt.Errorf("createPoller GQL error: %s", result.Errors[0].Message)
+	}
+	if result.Data.CreatePoller.ID == "" {
+		return "", fmt.Errorf("createPoller returned empty ID")
+	}
+
+	c.logger.V(3).Info("created poller", "id", result.Data.CreatePoller.ID, "name", result.Data.CreatePoller.Name)
+	return result.Data.CreatePoller.ID, nil
+}
+
+func (c *gqlClient) updatePoller(token, pollerID string, cfg *PollerConfig, region, assumeRoleArn string) error {
+	query := buildUpdatePollerMutation(pollerID, cfg, region, assumeRoleArn)
+	body, err := c.execute(token, query)
+	if err != nil {
+		return err
+	}
+
+	var result updatePollerResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		return fmt.Errorf("failed to parse updatePoller response: %w", err)
+	}
+	if len(result.Errors) > 0 {
+		return fmt.Errorf("updatePoller GQL error: %s", result.Errors[0].Message)
+	}
+
+	c.logger.V(3).Info("updated poller", "id", result.Data.UpdatePoller.ID)
+	return nil
+}
+
+func (c *gqlClient) deletePoller(token, pollerID string) error {
+	query := buildDeletePollerMutation(pollerID)
+	body, err := c.execute(token, query)
+	if err != nil {
+		return err
+	}
+
+	var result deletePollerResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		return fmt.Errorf("failed to parse deletePoller response: %w", err)
+	}
+	if len(result.Errors) > 0 {
+		return fmt.Errorf("deletePoller GQL error: %s", result.Errors[0].Message)
+	}
+
+	c.logger.V(3).Info("deleted poller", "id", pollerID)
+	return nil
+}

--- a/pkg/handler/pollerconfigurator/gql.go
+++ b/pkg/handler/pollerconfigurator/gql.go
@@ -6,15 +6,27 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 
 	"github.com/go-logr/logr"
 )
 
 const bearerTokenFormat = "Bearer %s %s"
 
+const createPollerMutation = `mutation CreatePoller($workspaceId: ObjectId!, $poller: PollerInput!) {
+	createPoller(workspaceId: $workspaceId, poller: $poller) { id name }
+}`
+
+const updatePollerMutation = `mutation UpdatePoller($id: ObjectId!, $poller: PollerInput!) {
+	updatePoller(id: $id, poller: $poller) { id name }
+}`
+
+const deletePollerMutation = `mutation DeletePoller($id: ObjectId!) {
+	deletePoller(id: $id) { success }
+}`
+
 type graphQLRequest struct {
-	Query string `json:"query"`
+	Query     string      `json:"query"`
+	Variables interface{} `json:"variables,omitempty"`
 }
 
 type createPollerResponse struct {
@@ -52,104 +64,99 @@ type deletePollerResponse struct {
 	} `json:"errors"`
 }
 
-func buildQueriesGQL(queries []QueryConfig) string {
-	var parts []string
-	for _, q := range queries {
-		var fields []string
-		fields = append(fields, fmt.Sprintf(`namespace: %q`, q.Namespace))
+// GQL variable input types — serialized as JSON and sent in the
+// "variables" field of the GraphQL request. Field names and string
+// encoding (e.g. period as "300") match the Observe v1/meta schema.
 
-		if len(q.MetricNames) > 0 {
-			names := make([]string, len(q.MetricNames))
-			for i, n := range q.MetricNames {
-				names[i] = fmt.Sprintf("%q", n)
-			}
-			fields = append(fields, fmt.Sprintf(`metricNames: [%s]`, strings.Join(names, ", ")))
+type pollerInput struct {
+	Name                    string                `json:"name,omitempty"`
+	DatastreamId            string                `json:"datastreamId,omitempty"`
+	Interval                string                `json:"interval,omitempty"`
+	Retries                 *string               `json:"retries,omitempty"`
+	CloudWatchMetricsConfig *cwMetricsConfigInput `json:"cloudWatchMetricsConfig"`
+}
+
+type cwMetricsConfigInput struct {
+	Period        string             `json:"period"`
+	Delay         string             `json:"delay"`
+	Region        string             `json:"region"`
+	AssumeRoleArn string             `json:"assumeRoleArn"`
+	Queries       []queryVarInput    `json:"queries"`
+}
+
+type queryVarInput struct {
+	Namespace      string                `json:"namespace"`
+	MetricNames    []string              `json:"metricNames,omitempty"`
+	Dimensions     []dimensionVarInput   `json:"dimensions,omitempty"`
+	ResourceFilter *resourceFilterInput  `json:"resourceFilter,omitempty"`
+}
+
+type dimensionVarInput struct {
+	Name  string `json:"name"`
+	Value string `json:"value,omitempty"`
+}
+
+type resourceFilterInput struct {
+	ResourceType  string            `json:"resourceType,omitempty"`
+	Pattern       string            `json:"pattern,omitempty"`
+	DimensionName string            `json:"dimensionName,omitempty"`
+	TagFilters    []tagFilterInput  `json:"tagFilters"`
+}
+
+type tagFilterInput struct {
+	Key    string   `json:"key"`
+	Values []string `json:"values,omitempty"`
+}
+
+func buildPollerInput(cfg *PollerConfig, region, assumeRoleArn string) pollerInput {
+	queries := make([]queryVarInput, len(cfg.Queries))
+	for i, q := range cfg.Queries {
+		qv := queryVarInput{
+			Namespace:   q.Namespace,
+			MetricNames: q.MetricNames,
 		}
-
 		if len(q.Dimensions) > 0 {
-			var dims []string
-			for _, d := range q.Dimensions {
-				if d.Value != "" {
-					dims = append(dims, fmt.Sprintf(`{name: %q, value: %q}`, d.Name, d.Value))
-				} else {
-					dims = append(dims, fmt.Sprintf(`{name: %q}`, d.Name))
-				}
+			qv.Dimensions = make([]dimensionVarInput, len(q.Dimensions))
+			for j, d := range q.Dimensions {
+				qv.Dimensions[j] = dimensionVarInput(d)
 			}
-			fields = append(fields, fmt.Sprintf(`dimensions: [%s]`, strings.Join(dims, ", ")))
 		}
-
 		if q.ResourceFilter != nil {
-			rf := q.ResourceFilter
-			var rfFields []string
-			if rf.ResourceType != "" {
-				rfFields = append(rfFields, fmt.Sprintf(`resourceType: %q`, rf.ResourceType))
+			rf := &resourceFilterInput{
+				ResourceType:  q.ResourceFilter.ResourceType,
+				Pattern:       q.ResourceFilter.Pattern,
+				DimensionName: q.ResourceFilter.DimensionName,
 			}
-			if rf.Pattern != "" {
-				rfFields = append(rfFields, fmt.Sprintf(`pattern: %q`, rf.Pattern))
-			}
-			if rf.DimensionName != "" {
-				rfFields = append(rfFields, fmt.Sprintf(`dimensionName: %q`, rf.DimensionName))
-			}
-			var tagParts []string
-			for _, tf := range rf.TagFilters {
-				if len(tf.Values) > 0 {
-					vals := make([]string, len(tf.Values))
-					for i, v := range tf.Values {
-						vals[i] = fmt.Sprintf("%q", v)
-					}
-					tagParts = append(tagParts, fmt.Sprintf(`{key: %q, values: [%s]}`, tf.Key, strings.Join(vals, ", ")))
-				} else {
-					tagParts = append(tagParts, fmt.Sprintf(`{key: %q}`, tf.Key))
+			if len(q.ResourceFilter.TagFilters) > 0 {
+				rf.TagFilters = make([]tagFilterInput, len(q.ResourceFilter.TagFilters))
+				for k, tf := range q.ResourceFilter.TagFilters {
+					rf.TagFilters[k] = tagFilterInput(tf)
 				}
 			}
-			rfFields = append(rfFields, fmt.Sprintf(`tagFilters: [%s]`, strings.Join(tagParts, ", ")))
-			fields = append(fields, fmt.Sprintf(`resourceFilter: {%s}`, strings.Join(rfFields, ", ")))
+			qv.ResourceFilter = rf
 		}
+		queries[i] = qv
+	}
 
-		parts = append(parts, fmt.Sprintf(`{%s}`, strings.Join(fields, ", ")))
+	input := pollerInput{
+		Name:         cfg.Name,
+		DatastreamId: cfg.DatastreamId,
+		Interval:     cfg.Interval,
+		CloudWatchMetricsConfig: &cwMetricsConfigInput{
+			Period:        fmt.Sprintf("%d", cfg.Period),
+			Delay:         fmt.Sprintf("%d", cfg.Delay),
+			Region:        region,
+			AssumeRoleArn: assumeRoleArn,
+			Queries:       queries,
+		},
 	}
-	return fmt.Sprintf("[%s]", strings.Join(parts, ", "))
-}
 
-func buildPollerInputGQL(cfg *PollerConfig, region, assumeRoleArn string) string {
-	var fields []string
-	if cfg.Name != "" {
-		fields = append(fields, fmt.Sprintf(`name: %q`, cfg.Name))
-	}
-	if cfg.DatastreamId != "" {
-		fields = append(fields, fmt.Sprintf(`datastreamId: %q`, cfg.DatastreamId))
-	}
-	if cfg.Interval != "" {
-		fields = append(fields, fmt.Sprintf(`interval: %q`, cfg.Interval))
-	}
 	if cfg.Retries != nil {
-		fields = append(fields, fmt.Sprintf(`retries: "%d"`, *cfg.Retries))
+		s := fmt.Sprintf("%d", *cfg.Retries)
+		input.Retries = &s
 	}
 
-	cwFields := []string{
-		fmt.Sprintf(`period: "%d"`, cfg.Period),
-		fmt.Sprintf(`delay: "%d"`, cfg.Delay),
-		fmt.Sprintf(`region: %q`, region),
-		fmt.Sprintf(`assumeRoleArn: %q`, assumeRoleArn),
-		fmt.Sprintf(`queries: %s`, buildQueriesGQL(cfg.Queries)),
-	}
-
-	fields = append(fields, fmt.Sprintf(`cloudWatchMetricsConfig: {%s}`, strings.Join(cwFields, ", ")))
-	return fmt.Sprintf(`{%s}`, strings.Join(fields, ", "))
-}
-
-func buildCreatePollerMutation(workspaceID string, cfg *PollerConfig, region, assumeRoleArn string) string {
-	input := buildPollerInputGQL(cfg, region, assumeRoleArn)
-	return fmt.Sprintf(`mutation { createPoller(workspaceId: %q, poller: %s) { id name } }`, workspaceID, input)
-}
-
-func buildUpdatePollerMutation(pollerID string, cfg *PollerConfig, region, assumeRoleArn string) string {
-	input := buildPollerInputGQL(cfg, region, assumeRoleArn)
-	return fmt.Sprintf(`mutation { updatePoller(id: %q, poller: %s) { id name } }`, pollerID, input)
-}
-
-func buildDeletePollerMutation(pollerID string) string {
-	return fmt.Sprintf(`mutation { deletePoller(id: %q) { success } }`, pollerID)
+	return input
 }
 
 type gqlClient struct {
@@ -159,10 +166,10 @@ type gqlClient struct {
 	logger            logr.Logger
 }
 
-func (c *gqlClient) execute(token, query string) ([]byte, error) {
+func (c *gqlClient) execute(token, query string, variables interface{}) ([]byte, error) {
 	fullToken := fmt.Sprintf(bearerTokenFormat, c.observeAccountID, token)
 
-	jsonData, err := json.Marshal(graphQLRequest{Query: query})
+	jsonData, err := json.Marshal(graphQLRequest{Query: query, Variables: variables})
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal GQL request: %w", err)
 	}
@@ -199,8 +206,13 @@ func (c *gqlClient) execute(token, query string) ([]byte, error) {
 }
 
 func (c *gqlClient) createPoller(token, workspaceID string, cfg *PollerConfig, region, assumeRoleArn string) (string, error) {
-	query := buildCreatePollerMutation(workspaceID, cfg, region, assumeRoleArn)
-	body, err := c.execute(token, query)
+	input := buildPollerInput(cfg, region, assumeRoleArn)
+	variables := map[string]interface{}{
+		"workspaceId": workspaceID,
+		"poller":      input,
+	}
+
+	body, err := c.execute(token, createPollerMutation, variables)
 	if err != nil {
 		return "", err
 	}
@@ -221,8 +233,13 @@ func (c *gqlClient) createPoller(token, workspaceID string, cfg *PollerConfig, r
 }
 
 func (c *gqlClient) updatePoller(token, pollerID string, cfg *PollerConfig, region, assumeRoleArn string) error {
-	query := buildUpdatePollerMutation(pollerID, cfg, region, assumeRoleArn)
-	body, err := c.execute(token, query)
+	input := buildPollerInput(cfg, region, assumeRoleArn)
+	variables := map[string]interface{}{
+		"id":     pollerID,
+		"poller": input,
+	}
+
+	body, err := c.execute(token, updatePollerMutation, variables)
 	if err != nil {
 		return err
 	}
@@ -240,8 +257,11 @@ func (c *gqlClient) updatePoller(token, pollerID string, cfg *PollerConfig, regi
 }
 
 func (c *gqlClient) deletePoller(token, pollerID string) error {
-	query := buildDeletePollerMutation(pollerID)
-	body, err := c.execute(token, query)
+	variables := map[string]interface{}{
+		"id": pollerID,
+	}
+
+	body, err := c.execute(token, deletePollerMutation, variables)
 	if err != nil {
 		return err
 	}

--- a/pkg/handler/pollerconfigurator/gql_test.go
+++ b/pkg/handler/pollerconfigurator/gql_test.go
@@ -1,0 +1,226 @@
+package pollerconfigurator
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildQueriesGQL(t *testing.T) {
+	tests := []struct {
+		name     string
+		queries  []QueryConfig
+		contains []string
+	}{
+		{
+			name: "simple namespace",
+			queries: []QueryConfig{
+				{Namespace: "AWS/EC2"},
+			},
+			contains: []string{`namespace: "AWS/EC2"`},
+		},
+		{
+			name: "with metric names",
+			queries: []QueryConfig{
+				{
+					Namespace:   "AWS/EC2",
+					MetricNames: []string{"CPUUtilization", "NetworkIn"},
+				},
+			},
+			contains: []string{
+				`namespace: "AWS/EC2"`,
+				`metricNames: ["CPUUtilization", "NetworkIn"]`,
+			},
+		},
+		{
+			name: "with dimensions",
+			queries: []QueryConfig{
+				{
+					Namespace: "AWS/EC2",
+					Dimensions: []DimensionFilter{
+						{Name: "InstanceId", Value: "i-1234"},
+					},
+				},
+			},
+			contains: []string{
+				`dimensions: [{name: "InstanceId", value: "i-1234"}]`,
+			},
+		},
+		{
+			name: "with resource filter and tag filters",
+			queries: []QueryConfig{
+				{
+					Namespace: "AWS/EC2",
+					ResourceFilter: &ResourceFilter{
+						ResourceType: "AWS::EC2::Instance",
+						TagFilters: []TagFilter{
+							{Key: "Environment", Values: []string{"prod", "staging"}},
+						},
+					},
+				},
+			},
+			contains: []string{
+				`resourceType: "AWS::EC2::Instance"`,
+				`key: "Environment"`,
+				`values: ["prod", "staging"]`,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := buildQueriesGQL(tt.queries)
+			for _, substr := range tt.contains {
+				if !strings.Contains(result, substr) {
+					t.Errorf("buildQueriesGQL() = %q, missing %q", result, substr)
+				}
+			}
+		})
+	}
+}
+
+func TestBuildCreatePollerMutation(t *testing.T) {
+	cfg := &PollerConfig{
+		Name:         "test-poller",
+		DatastreamId: "ds-999",
+		Period:       300,
+		Delay:        300,
+		Queries: []QueryConfig{
+			{Namespace: "AWS/EC2", MetricNames: []string{"CPUUtilization"}},
+		},
+	}
+
+	result := buildCreatePollerMutation("12345", cfg, "us-east-1", "arn:aws:iam::999:role/observe")
+
+	expects := []string{
+		`mutation`,
+		`createPoller`,
+		`workspaceId: "12345"`,
+		`name: "test-poller"`,
+		`datastreamId: "ds-999"`,
+		`period: "300"`,
+		`delay: "300"`,
+		`region: "us-east-1"`,
+		`assumeRoleArn: "arn:aws:iam::999:role/observe"`,
+		`namespace: "AWS/EC2"`,
+		`metricNames: ["CPUUtilization"]`,
+		`{ id name }`,
+	}
+
+	for _, exp := range expects {
+		if !strings.Contains(result, exp) {
+			t.Errorf("buildCreatePollerMutation() missing %q in:\n%s", exp, result)
+		}
+	}
+}
+
+func TestBuildUpdatePollerMutation(t *testing.T) {
+	cfg := &PollerConfig{
+		Name:         "updated-poller",
+		DatastreamId: "ds-111",
+		Period:       600,
+		Delay:        600,
+		Queries: []QueryConfig{
+			{Namespace: "AWS/Lambda"},
+		},
+	}
+
+	result := buildUpdatePollerMutation("67890", cfg, "eu-west-1", "arn:aws:iam::111:role/obs")
+
+	expects := []string{
+		`mutation`,
+		`updatePoller`,
+		`id: "67890"`,
+		`name: "updated-poller"`,
+		`datastreamId: "ds-111"`,
+		`period: "600"`,
+		`region: "eu-west-1"`,
+	}
+
+	for _, exp := range expects {
+		if !strings.Contains(result, exp) {
+			t.Errorf("buildUpdatePollerMutation() missing %q in:\n%s", exp, result)
+		}
+	}
+}
+
+func TestBuildDeletePollerMutation(t *testing.T) {
+	result := buildDeletePollerMutation("99999")
+
+	expects := []string{
+		`mutation`,
+		`deletePoller`,
+		`id: "99999"`,
+		`success`,
+	}
+
+	for _, exp := range expects {
+		if !strings.Contains(result, exp) {
+			t.Errorf("buildDeletePollerMutation() missing %q in:\n%s", exp, result)
+		}
+	}
+}
+
+func TestBuildPollerInputGQL_WithOptionalFields(t *testing.T) {
+	retries := int64(3)
+	cfg := &PollerConfig{
+		Name:     "my-poller",
+		Period:   300,
+		Delay:    300,
+		Interval: "1m",
+		Retries:  &retries,
+		Queries: []QueryConfig{
+			{Namespace: "AWS/EC2"},
+		},
+	}
+
+	result := buildPollerInputGQL(cfg, "us-west-2", "arn:aws:iam::123:role/test")
+
+	expects := []string{
+		`interval: "1m"`,
+		`retries: "3"`,
+		`cloudWatchMetricsConfig:`,
+	}
+
+	for _, exp := range expects {
+		if !strings.Contains(result, exp) {
+			t.Errorf("buildPollerInputGQL() missing %q in:\n%s", exp, result)
+		}
+	}
+}
+
+func TestBuildQueriesGQL_DimensionWithoutValue(t *testing.T) {
+	queries := []QueryConfig{
+		{
+			Namespace: "AWS/EC2",
+			Dimensions: []DimensionFilter{
+				{Name: "InstanceId"},
+			},
+		},
+	}
+
+	result := buildQueriesGQL(queries)
+	if !strings.Contains(result, `{name: "InstanceId"}`) {
+		t.Errorf("expected dimension without value, got: %s", result)
+	}
+	if strings.Contains(result, `value:`) {
+		t.Errorf("should not contain value field for empty value, got: %s", result)
+	}
+}
+
+func TestBuildQueriesGQL_TagFilterWithoutValues(t *testing.T) {
+	queries := []QueryConfig{
+		{
+			Namespace: "AWS/EC2",
+			ResourceFilter: &ResourceFilter{
+				TagFilters: []TagFilter{
+					{Key: "Team"},
+				},
+			},
+		},
+	}
+
+	result := buildQueriesGQL(queries)
+	if !strings.Contains(result, `{key: "Team"}`) {
+		t.Errorf("expected tag filter without values, got: %s", result)
+	}
+}

--- a/pkg/handler/pollerconfigurator/gql_test.go
+++ b/pkg/handler/pollerconfigurator/gql_test.go
@@ -1,166 +1,62 @@
 package pollerconfigurator
 
 import (
-	"strings"
+	"encoding/json"
 	"testing"
 )
 
-func TestBuildQueriesGQL(t *testing.T) {
-	tests := []struct {
-		name     string
-		queries  []QueryConfig
-		contains []string
-	}{
-		{
-			name: "simple namespace",
-			queries: []QueryConfig{
-				{Namespace: "AWS/EC2"},
-			},
-			contains: []string{`namespace: "AWS/EC2"`},
-		},
-		{
-			name: "with metric names",
-			queries: []QueryConfig{
-				{
-					Namespace:   "AWS/EC2",
-					MetricNames: []string{"CPUUtilization", "NetworkIn"},
-				},
-			},
-			contains: []string{
-				`namespace: "AWS/EC2"`,
-				`metricNames: ["CPUUtilization", "NetworkIn"]`,
-			},
-		},
-		{
-			name: "with dimensions",
-			queries: []QueryConfig{
-				{
-					Namespace: "AWS/EC2",
-					Dimensions: []DimensionFilter{
-						{Name: "InstanceId", Value: "i-1234"},
-					},
-				},
-			},
-			contains: []string{
-				`dimensions: [{name: "InstanceId", value: "i-1234"}]`,
-			},
-		},
-		{
-			name: "with resource filter and tag filters",
-			queries: []QueryConfig{
-				{
-					Namespace: "AWS/EC2",
-					ResourceFilter: &ResourceFilter{
-						ResourceType: "AWS::EC2::Instance",
-						TagFilters: []TagFilter{
-							{Key: "Environment", Values: []string{"prod", "staging"}},
-						},
-					},
-				},
-			},
-			contains: []string{
-				`resourceType: "AWS::EC2::Instance"`,
-				`key: "Environment"`,
-				`values: ["prod", "staging"]`,
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := buildQueriesGQL(tt.queries)
-			for _, substr := range tt.contains {
-				if !strings.Contains(result, substr) {
-					t.Errorf("buildQueriesGQL() = %q, missing %q", result, substr)
-				}
-			}
-		})
-	}
-}
-
-func TestBuildCreatePollerMutation(t *testing.T) {
+func TestBuildPollerInput_BasicFields(t *testing.T) {
 	cfg := &PollerConfig{
 		Name:         "test-poller",
 		DatastreamId: "ds-999",
 		Period:       300,
-		Delay:        300,
+		Delay:        60,
+		Interval:     "5m",
 		Queries: []QueryConfig{
 			{Namespace: "AWS/EC2", MetricNames: []string{"CPUUtilization"}},
 		},
 	}
 
-	result := buildCreatePollerMutation("12345", cfg, "us-east-1", "arn:aws:iam::999:role/observe")
+	input := buildPollerInput(cfg, "us-east-1", "arn:aws:iam::999:role/observe")
 
-	expects := []string{
-		`mutation`,
-		`createPoller`,
-		`workspaceId: "12345"`,
-		`name: "test-poller"`,
-		`datastreamId: "ds-999"`,
-		`period: "300"`,
-		`delay: "300"`,
-		`region: "us-east-1"`,
-		`assumeRoleArn: "arn:aws:iam::999:role/observe"`,
-		`namespace: "AWS/EC2"`,
-		`metricNames: ["CPUUtilization"]`,
-		`{ id name }`,
+	if input.Name != "test-poller" {
+		t.Errorf("Name = %q, want %q", input.Name, "test-poller")
+	}
+	if input.DatastreamId != "ds-999" {
+		t.Errorf("DatastreamId = %q, want %q", input.DatastreamId, "ds-999")
+	}
+	if input.Interval != "5m" {
+		t.Errorf("Interval = %q, want %q", input.Interval, "5m")
+	}
+	if input.Retries != nil {
+		t.Errorf("Retries = %v, want nil", input.Retries)
 	}
 
-	for _, exp := range expects {
-		if !strings.Contains(result, exp) {
-			t.Errorf("buildCreatePollerMutation() missing %q in:\n%s", exp, result)
-		}
+	cw := input.CloudWatchMetricsConfig
+	if cw == nil {
+		t.Fatal("CloudWatchMetricsConfig is nil")
 	}
-}
-
-func TestBuildUpdatePollerMutation(t *testing.T) {
-	cfg := &PollerConfig{
-		Name:         "updated-poller",
-		DatastreamId: "ds-111",
-		Period:       600,
-		Delay:        600,
-		Queries: []QueryConfig{
-			{Namespace: "AWS/Lambda"},
-		},
+	if cw.Period != "300" {
+		t.Errorf("Period = %q, want %q", cw.Period, "300")
 	}
-
-	result := buildUpdatePollerMutation("67890", cfg, "eu-west-1", "arn:aws:iam::111:role/obs")
-
-	expects := []string{
-		`mutation`,
-		`updatePoller`,
-		`id: "67890"`,
-		`name: "updated-poller"`,
-		`datastreamId: "ds-111"`,
-		`period: "600"`,
-		`region: "eu-west-1"`,
+	if cw.Delay != "60" {
+		t.Errorf("Delay = %q, want %q", cw.Delay, "60")
 	}
-
-	for _, exp := range expects {
-		if !strings.Contains(result, exp) {
-			t.Errorf("buildUpdatePollerMutation() missing %q in:\n%s", exp, result)
-		}
+	if cw.Region != "us-east-1" {
+		t.Errorf("Region = %q, want %q", cw.Region, "us-east-1")
+	}
+	if cw.AssumeRoleArn != "arn:aws:iam::999:role/observe" {
+		t.Errorf("AssumeRoleArn = %q, want %q", cw.AssumeRoleArn, "arn:aws:iam::999:role/observe")
+	}
+	if len(cw.Queries) != 1 || cw.Queries[0].Namespace != "AWS/EC2" {
+		t.Errorf("Queries = %+v, want 1 query with namespace AWS/EC2", cw.Queries)
+	}
+	if len(cw.Queries[0].MetricNames) != 1 || cw.Queries[0].MetricNames[0] != "CPUUtilization" {
+		t.Errorf("MetricNames = %v, want [CPUUtilization]", cw.Queries[0].MetricNames)
 	}
 }
 
-func TestBuildDeletePollerMutation(t *testing.T) {
-	result := buildDeletePollerMutation("99999")
-
-	expects := []string{
-		`mutation`,
-		`deletePoller`,
-		`id: "99999"`,
-		`success`,
-	}
-
-	for _, exp := range expects {
-		if !strings.Contains(result, exp) {
-			t.Errorf("buildDeletePollerMutation() missing %q in:\n%s", exp, result)
-		}
-	}
-}
-
-func TestBuildPollerInputGQL_WithOptionalFields(t *testing.T) {
+func TestBuildPollerInput_WithRetries(t *testing.T) {
 	retries := int64(3)
 	cfg := &PollerConfig{
 		Name:     "my-poller",
@@ -168,59 +64,200 @@ func TestBuildPollerInputGQL_WithOptionalFields(t *testing.T) {
 		Delay:    300,
 		Interval: "1m",
 		Retries:  &retries,
+		Queries:  []QueryConfig{{Namespace: "AWS/EC2"}},
+	}
+
+	input := buildPollerInput(cfg, "us-west-2", "arn:aws:iam::123:role/test")
+
+	if input.Retries == nil || *input.Retries != "3" {
+		t.Errorf("Retries = %v, want pointer to %q", input.Retries, "3")
+	}
+}
+
+func TestBuildPollerInput_Dimensions(t *testing.T) {
+	cfg := &PollerConfig{
+		Period: 300, Delay: 300, Interval: "5m",
 		Queries: []QueryConfig{
-			{Namespace: "AWS/EC2"},
-		},
-	}
-
-	result := buildPollerInputGQL(cfg, "us-west-2", "arn:aws:iam::123:role/test")
-
-	expects := []string{
-		`interval: "1m"`,
-		`retries: "3"`,
-		`cloudWatchMetricsConfig:`,
-	}
-
-	for _, exp := range expects {
-		if !strings.Contains(result, exp) {
-			t.Errorf("buildPollerInputGQL() missing %q in:\n%s", exp, result)
-		}
-	}
-}
-
-func TestBuildQueriesGQL_DimensionWithoutValue(t *testing.T) {
-	queries := []QueryConfig{
-		{
-			Namespace: "AWS/EC2",
-			Dimensions: []DimensionFilter{
-				{Name: "InstanceId"},
-			},
-		},
-	}
-
-	result := buildQueriesGQL(queries)
-	if !strings.Contains(result, `{name: "InstanceId"}`) {
-		t.Errorf("expected dimension without value, got: %s", result)
-	}
-	if strings.Contains(result, `value:`) {
-		t.Errorf("should not contain value field for empty value, got: %s", result)
-	}
-}
-
-func TestBuildQueriesGQL_TagFilterWithoutValues(t *testing.T) {
-	queries := []QueryConfig{
-		{
-			Namespace: "AWS/EC2",
-			ResourceFilter: &ResourceFilter{
-				TagFilters: []TagFilter{
-					{Key: "Team"},
+			{
+				Namespace: "AWS/EC2",
+				Dimensions: []DimensionFilter{
+					{Name: "InstanceId", Value: "i-1234"},
+					{Name: "AutoScalingGroupName"},
 				},
 			},
 		},
 	}
 
-	result := buildQueriesGQL(queries)
-	if !strings.Contains(result, `{key: "Team"}`) {
-		t.Errorf("expected tag filter without values, got: %s", result)
+	input := buildPollerInput(cfg, "us-east-1", "arn:role")
+	dims := input.CloudWatchMetricsConfig.Queries[0].Dimensions
+	if len(dims) != 2 {
+		t.Fatalf("got %d dimensions, want 2", len(dims))
 	}
+	if dims[0].Name != "InstanceId" || dims[0].Value != "i-1234" {
+		t.Errorf("dims[0] = %+v, want {InstanceId, i-1234}", dims[0])
+	}
+	if dims[1].Name != "AutoScalingGroupName" || dims[1].Value != "" {
+		t.Errorf("dims[1] = %+v, want {AutoScalingGroupName, (empty)}", dims[1])
+	}
+}
+
+func TestBuildPollerInput_DimensionWithoutValue_OmittedInJSON(t *testing.T) {
+	cfg := &PollerConfig{
+		Period: 300, Delay: 300, Interval: "5m",
+		Queries: []QueryConfig{
+			{
+				Namespace:  "AWS/EC2",
+				Dimensions: []DimensionFilter{{Name: "InstanceId"}},
+			},
+		},
+	}
+
+	input := buildPollerInput(cfg, "us-east-1", "arn:role")
+	data, err := json.Marshal(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var raw map[string]interface{}
+	_ = json.Unmarshal(data, &raw)
+	cw := raw["cloudWatchMetricsConfig"].(map[string]interface{})
+	queries := cw["queries"].([]interface{})
+	q := queries[0].(map[string]interface{})
+	dims := q["dimensions"].([]interface{})
+	d := dims[0].(map[string]interface{})
+
+	if _, exists := d["value"]; exists {
+		t.Error("expected empty value to be omitted from JSON")
+	}
+}
+
+func TestBuildPollerInput_ResourceFilter(t *testing.T) {
+	cfg := &PollerConfig{
+		Period: 300, Delay: 300, Interval: "5m",
+		Queries: []QueryConfig{
+			{
+				Namespace: "AWS/EC2",
+				ResourceFilter: &ResourceFilter{
+					ResourceType:  "AWS::EC2::Instance",
+					Pattern:       "prod-*",
+					DimensionName: "InstanceId",
+					TagFilters: []TagFilter{
+						{Key: "Environment", Values: []string{"prod", "staging"}},
+						{Key: "Team"},
+					},
+				},
+			},
+		},
+	}
+
+	input := buildPollerInput(cfg, "us-east-1", "arn:role")
+	rf := input.CloudWatchMetricsConfig.Queries[0].ResourceFilter
+	if rf == nil {
+		t.Fatal("ResourceFilter is nil")
+	}
+	if rf.ResourceType != "AWS::EC2::Instance" {
+		t.Errorf("ResourceType = %q, want %q", rf.ResourceType, "AWS::EC2::Instance")
+	}
+	if rf.Pattern != "prod-*" {
+		t.Errorf("Pattern = %q, want %q", rf.Pattern, "prod-*")
+	}
+	if rf.DimensionName != "InstanceId" {
+		t.Errorf("DimensionName = %q, want %q", rf.DimensionName, "InstanceId")
+	}
+	if len(rf.TagFilters) != 2 {
+		t.Fatalf("got %d tag filters, want 2", len(rf.TagFilters))
+	}
+	if rf.TagFilters[0].Key != "Environment" || len(rf.TagFilters[0].Values) != 2 {
+		t.Errorf("TagFilters[0] = %+v, want {Environment, [prod staging]}", rf.TagFilters[0])
+	}
+	if rf.TagFilters[1].Key != "Team" || len(rf.TagFilters[1].Values) != 0 {
+		t.Errorf("TagFilters[1] = %+v, want {Team, []}", rf.TagFilters[1])
+	}
+}
+
+func TestBuildPollerInput_JSONRoundTrip(t *testing.T) {
+	retries := int64(5)
+	cfg := &PollerConfig{
+		Name:         "roundtrip-test",
+		DatastreamId: "ds-42",
+		Period:       600,
+		Delay:        120,
+		Interval:     "10m",
+		Retries:      &retries,
+		Queries: []QueryConfig{
+			{
+				Namespace:   "AWS/Lambda",
+				MetricNames: []string{"Invocations", "Errors"},
+				Dimensions:  []DimensionFilter{{Name: "FunctionName", Value: "my-fn"}},
+			},
+		},
+	}
+
+	input := buildPollerInput(cfg, "eu-west-1", "arn:aws:iam::111:role/obs")
+	data, err := json.Marshal(input)
+	if err != nil {
+		t.Fatalf("json.Marshal failed: %v", err)
+	}
+
+	var roundtripped pollerInput
+	if err := json.Unmarshal(data, &roundtripped); err != nil {
+		t.Fatalf("json.Unmarshal failed: %v", err)
+	}
+
+	if roundtripped.Name != "roundtrip-test" {
+		t.Errorf("Name = %q after roundtrip", roundtripped.Name)
+	}
+	if roundtripped.CloudWatchMetricsConfig.Period != "600" {
+		t.Errorf("Period = %q after roundtrip, want %q", roundtripped.CloudWatchMetricsConfig.Period, "600")
+	}
+	if roundtripped.Retries == nil || *roundtripped.Retries != "5" {
+		t.Errorf("Retries = %v after roundtrip, want %q", roundtripped.Retries, "5")
+	}
+}
+
+func TestMutationConstants(t *testing.T) {
+	tests := []struct {
+		name     string
+		mutation string
+		want     []string
+	}{
+		{
+			name:     "create",
+			mutation: createPollerMutation,
+			want:     []string{"mutation", "createPoller", "$workspaceId", "$poller", "id", "name"},
+		},
+		{
+			name:     "update",
+			mutation: updatePollerMutation,
+			want:     []string{"mutation", "updatePoller", "$id", "$poller", "id", "name"},
+		},
+		{
+			name:     "delete",
+			mutation: deletePollerMutation,
+			want:     []string{"mutation", "deletePoller", "$id", "success"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, w := range tt.want {
+				if !contains(tt.mutation, w) {
+					t.Errorf("%s mutation missing %q", tt.name, w)
+				}
+			}
+		})
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && searchString(s, substr)
+}
+
+func searchString(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/handler/pollerconfigurator/handler.go
+++ b/pkg/handler/pollerconfigurator/handler.go
@@ -1,0 +1,254 @@
+package pollerconfigurator
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+	"github.com/go-logr/logr"
+)
+
+type Handler struct {
+	Logger            logr.Logger
+	ObserveAccountID  string
+	ObserveDomainName string
+	SecretName        string
+	PollerConfigURI   string
+	ExternalRoleName  string
+	WorkspaceID       string
+	Region            string
+	AWSAccountID      string
+}
+
+func New(cfg *Config, logger logr.Logger) (Handler, error) {
+	return Handler{
+		Logger:            logger,
+		ObserveAccountID:  cfg.ObserveAccountID,
+		ObserveDomainName: cfg.ObserveDomainName,
+		SecretName:        cfg.SecretName,
+		PollerConfigURI:   cfg.PollerConfigURI,
+		ExternalRoleName:  cfg.ExternalRoleName,
+		WorkspaceID:       cfg.WorkspaceID,
+		Region:            cfg.Region,
+		AWSAccountID:      cfg.AWSAccountID,
+	}, nil
+}
+
+func (h Handler) Invoke(ctx context.Context, payload []byte) ([]byte, error) {
+	logger := h.Logger
+	logger.V(4).Info("handling poller configurator request")
+
+	req, err := h.parsePayload(payload)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse payload: %w", err)
+	}
+	logger.V(3).Info("parsed request", "requestType", req.RequestType, "physicalResourceId", req.PhysicalResourceId)
+
+	awsCfg, err := awsconfig.LoadDefaultConfig(ctx)
+	if err != nil {
+		if req.RequestType == "Delete" {
+			logger.Error(err, "failed to load AWS config during delete, skipping poller cleanup")
+			if reportErr := h.reportStatus(*req, true, "deleted (skipped poller cleanup: could not load AWS config)"); reportErr != nil {
+				return nil, fmt.Errorf("failed to report success: %w", reportErr)
+			}
+			return []byte{}, nil
+		}
+		return nil, h.reportAndError("failed to load AWS config", req, err)
+	}
+
+	token, err := h.getSecretValue(ctx, awsCfg)
+	if err != nil {
+		if req.RequestType == "Delete" {
+			logger.Error(err, "failed to retrieve GQL token during delete, skipping poller cleanup")
+			if reportErr := h.reportStatus(*req, true, "deleted (skipped poller cleanup: could not retrieve token)"); reportErr != nil {
+				return nil, fmt.Errorf("failed to report success: %w", reportErr)
+			}
+			return []byte{}, nil
+		}
+		return nil, h.reportAndError("failed to retrieve GQL token", req, err)
+	}
+
+	gql := &gqlClient{
+		httpClient:        &http.Client{},
+		observeAccountID:  h.ObserveAccountID,
+		observeDomainName: h.ObserveDomainName,
+		logger:            logger,
+	}
+
+	assumeRoleArn := fmt.Sprintf("arn:aws:iam::%s:role/%s", h.AWSAccountID, h.ExternalRoleName)
+
+	switch req.RequestType {
+	case "Create":
+		return h.handleCreate(ctx, req, gql, token, assumeRoleArn)
+	case "Update":
+		return h.handleUpdate(ctx, req, gql, token, assumeRoleArn)
+	case "Delete":
+		return h.handleDelete(req, gql, token)
+	default:
+		return nil, h.reportAndError(fmt.Sprintf("unknown request type: %s", req.RequestType), req, nil)
+	}
+}
+
+func (h Handler) handleCreate(ctx context.Context, req *Request, gql *gqlClient, token *string, assumeRoleArn string) ([]byte, error) {
+	logger := h.Logger
+
+	pollerCfg, err := h.downloadConfig(ctx)
+	if err != nil {
+		return nil, h.reportAndError("failed to download poller config", req, err)
+	}
+	logger.V(3).Info("downloaded poller config", "queries", len(pollerCfg.Queries))
+
+	pollerCfg.Name = h.uniquePollerName(pollerCfg.Name)
+
+	pollerID, err := gql.createPoller(*token, h.WorkspaceID, pollerCfg, h.Region, assumeRoleArn)
+	if err != nil {
+		return nil, h.reportAndError("failed to create poller", req, err)
+	}
+
+	logger.V(3).Info("poller created", "id", pollerID)
+	if err := h.reportStatusWithPhysicalID(*req, true, "poller created successfully", pollerID); err != nil {
+		return nil, fmt.Errorf("failed to report success: %w", err)
+	}
+	return []byte{}, nil
+}
+
+func (h Handler) handleUpdate(ctx context.Context, req *Request, gql *gqlClient, token *string, assumeRoleArn string) ([]byte, error) {
+	logger := h.Logger
+
+	pollerID := req.PhysicalResourceId
+	if pollerID == "" {
+		return nil, h.reportAndError("update requires PhysicalResourceId (poller ID)", req, nil)
+	}
+
+	pollerCfg, err := h.downloadConfig(ctx)
+	if err != nil {
+		return nil, h.reportAndError("failed to download poller config", req, err)
+	}
+	logger.V(3).Info("downloaded poller config for update", "queries", len(pollerCfg.Queries))
+
+	pollerCfg.Name = h.uniquePollerName(pollerCfg.Name)
+
+	if err := gql.updatePoller(*token, pollerID, pollerCfg, h.Region, assumeRoleArn); err != nil {
+		return nil, h.reportAndError("failed to update poller", req, err)
+	}
+
+	logger.V(3).Info("poller updated", "id", pollerID)
+	if err := h.reportStatusWithPhysicalID(*req, true, "poller updated successfully", pollerID); err != nil {
+		return nil, fmt.Errorf("failed to report success: %w", err)
+	}
+	return []byte{}, nil
+}
+
+func (h Handler) handleDelete(req *Request, gql *gqlClient, token *string) ([]byte, error) {
+	logger := h.Logger
+
+	pollerID := req.PhysicalResourceId
+	if pollerID == "" {
+		logger.V(3).Info("no PhysicalResourceId on delete, reporting success")
+		if err := h.reportStatus(*req, true, "no poller to delete"); err != nil {
+			return nil, fmt.Errorf("failed to report success on empty delete: %w", err)
+		}
+		return []byte{}, nil
+	}
+
+	if err := gql.deletePoller(*token, pollerID); err != nil {
+		logger.Error(err, "failed to delete poller, continuing", "id", pollerID)
+	}
+
+	logger.V(3).Info("poller deleted", "id", pollerID)
+	if err := h.reportStatus(*req, true, "poller deleted successfully"); err != nil {
+		return nil, fmt.Errorf("failed to report success: %w", err)
+	}
+	return []byte{}, nil
+}
+
+func (h Handler) uniquePollerName(baseName string) string {
+	return fmt.Sprintf("%s-%s-%s", baseName, h.AWSAccountID, h.Region)
+}
+
+func (h Handler) downloadConfig(ctx context.Context) (*PollerConfig, error) {
+	return downloadPollerConfig(ctx, h.PollerConfigURI)
+}
+
+func (h Handler) getSecretValue(ctx context.Context, cfg aws.Config) (*string, error) {
+	svc := secretsmanager.NewFromConfig(cfg)
+	secretValue, err := svc.GetSecretValue(ctx, &secretsmanager.GetSecretValueInput{
+		SecretId: &h.SecretName,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve secret value: %w", err)
+	}
+	token := *secretValue.SecretString
+	return &token, nil
+}
+
+func (h Handler) parsePayload(payload []byte) (*Request, error) {
+	var req Request
+	if err := json.Unmarshal(payload, &req); err != nil {
+		return nil, fmt.Errorf("failed to decode payload: %w", err)
+	}
+	return &req, nil
+}
+
+func (h Handler) reportAndError(reason string, request *Request, err error) error {
+	cfnReason := reason
+	if err != nil {
+		cfnReason = fmt.Sprintf("%s: %v", reason, err)
+	}
+	reportErr := h.reportStatus(*request, false, cfnReason)
+	if reportErr != nil {
+		if err != nil {
+			return fmt.Errorf("failed to report status: %w, while reporting error, %s: %w", reportErr, reason, err)
+		}
+		return fmt.Errorf("failed to report status: %w, reason: %s", reportErr, reason)
+	}
+	if err != nil {
+		return fmt.Errorf("%s: %w", reason, err)
+	}
+	return fmt.Errorf("%s", reason)
+}
+
+func (h Handler) reportStatus(request Request, success bool, reason string) error {
+	return h.reportStatusWithPhysicalID(request, success, reason, request.PhysicalResourceId)
+}
+
+func (h Handler) reportStatusWithPhysicalID(request Request, success bool, reason, physicalResourceID string) error {
+	logger := h.Logger
+
+	statusString := "FAILED"
+	if success {
+		statusString = "SUCCESS"
+	}
+
+	if physicalResourceID == "" {
+		physicalResourceID = "lambda-pollerconfigurator"
+	}
+
+	resp := CfResponse{
+		Status:             statusString,
+		PhysicalResourceId: physicalResourceID,
+		Reason:             reason,
+		StackId:            request.StackId,
+		RequestId:          request.RequestId,
+		LogicalResourceId:  request.LogicalResourceId,
+	}
+
+	body, _ := json.Marshal(resp)
+	logger.V(4).Info("reporting status to cloudformation", "response", resp)
+
+	req, _ := http.NewRequest("PUT", request.ResponseURL, bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{}
+	_, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send response to cloudformation: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/handler/pollerconfigurator/handler.go
+++ b/pkg/handler/pollerconfigurator/handler.go
@@ -6,12 +6,15 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
 	"github.com/go-logr/logr"
 )
+
+const httpTimeout = 30 * time.Second
 
 type Handler struct {
 	Logger            logr.Logger
@@ -74,7 +77,7 @@ func (h Handler) Invoke(ctx context.Context, payload []byte) ([]byte, error) {
 	}
 
 	gql := &gqlClient{
-		httpClient:        &http.Client{},
+		httpClient:        &http.Client{Timeout: httpTimeout},
 		observeAccountID:  h.ObserveAccountID,
 		observeDomainName: h.ObserveDomainName,
 		logger:            logger,
@@ -84,9 +87,9 @@ func (h Handler) Invoke(ctx context.Context, payload []byte) ([]byte, error) {
 
 	switch req.RequestType {
 	case "Create":
-		return h.handleCreate(ctx, req, gql, token, assumeRoleArn)
+		return h.handleCreate(ctx, req, gql, token, assumeRoleArn, awsCfg)
 	case "Update":
-		return h.handleUpdate(ctx, req, gql, token, assumeRoleArn)
+		return h.handleUpdate(ctx, req, gql, token, assumeRoleArn, awsCfg)
 	case "Delete":
 		return h.handleDelete(req, gql, token)
 	default:
@@ -94,10 +97,10 @@ func (h Handler) Invoke(ctx context.Context, payload []byte) ([]byte, error) {
 	}
 }
 
-func (h Handler) handleCreate(ctx context.Context, req *Request, gql *gqlClient, token *string, assumeRoleArn string) ([]byte, error) {
+func (h Handler) handleCreate(ctx context.Context, req *Request, gql *gqlClient, token *string, assumeRoleArn string, awsCfg aws.Config) ([]byte, error) {
 	logger := h.Logger
 
-	pollerCfg, err := h.downloadConfig(ctx)
+	pollerCfg, err := h.downloadConfig(ctx, awsCfg)
 	if err != nil {
 		return nil, h.reportAndError("failed to download poller config", req, err)
 	}
@@ -117,7 +120,7 @@ func (h Handler) handleCreate(ctx context.Context, req *Request, gql *gqlClient,
 	return []byte{}, nil
 }
 
-func (h Handler) handleUpdate(ctx context.Context, req *Request, gql *gqlClient, token *string, assumeRoleArn string) ([]byte, error) {
+func (h Handler) handleUpdate(ctx context.Context, req *Request, gql *gqlClient, token *string, assumeRoleArn string, awsCfg aws.Config) ([]byte, error) {
 	logger := h.Logger
 
 	pollerID := req.PhysicalResourceId
@@ -125,7 +128,7 @@ func (h Handler) handleUpdate(ctx context.Context, req *Request, gql *gqlClient,
 		return nil, h.reportAndError("update requires PhysicalResourceId (poller ID)", req, nil)
 	}
 
-	pollerCfg, err := h.downloadConfig(ctx)
+	pollerCfg, err := h.downloadConfig(ctx, awsCfg)
 	if err != nil {
 		return nil, h.reportAndError("failed to download poller config", req, err)
 	}
@@ -171,8 +174,8 @@ func (h Handler) uniquePollerName(baseName string) string {
 	return fmt.Sprintf("%s-%s-%s", baseName, h.AWSAccountID, h.Region)
 }
 
-func (h Handler) downloadConfig(ctx context.Context) (*PollerConfig, error) {
-	return downloadPollerConfig(ctx, h.PollerConfigURI)
+func (h Handler) downloadConfig(ctx context.Context, awsCfg aws.Config) (*PollerConfig, error) {
+	return downloadPollerConfig(ctx, h.PollerConfigURI, awsCfg)
 }
 
 func (h Handler) getSecretValue(ctx context.Context, cfg aws.Config) (*string, error) {
@@ -244,7 +247,7 @@ func (h Handler) reportStatusWithPhysicalID(request Request, success bool, reaso
 	req, _ := http.NewRequest("PUT", request.ResponseURL, bytes.NewBuffer(body))
 	req.Header.Set("Content-Type", "application/json")
 
-	client := &http.Client{}
+	client := &http.Client{Timeout: httpTimeout}
 	_, err := client.Do(req)
 	if err != nil {
 		return fmt.Errorf("failed to send response to cloudformation: %w", err)

--- a/pkg/handler/pollerconfigurator/handler_test.go
+++ b/pkg/handler/pollerconfigurator/handler_test.go
@@ -1,0 +1,378 @@
+package pollerconfigurator
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr"
+)
+
+// mockRoundTripper intercepts HTTP requests so tests can inspect outgoing
+// GQL mutations and return canned responses without hitting a real server.
+type mockRoundTripper struct {
+	RoundTripFunc func(req *http.Request) (*http.Response, error)
+}
+
+func (m *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return m.RoundTripFunc(req)
+}
+
+// testPollerConfig is the JSON config served by the config httptest server.
+const testPollerConfig = `{
+	"name": "test-poller",
+	"datastreamId": "ds-999",
+	"interval": "5m",
+	"period": 300,
+	"delay": 300,
+	"queries": [{"namespace": "AWS/EC2", "metricNames": ["CPUUtilization"]}]
+}`
+
+// newConfigServer returns an httptest server that serves a valid poller config.
+func newConfigServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(testPollerConfig))
+	}))
+}
+
+// cfnCapture tracks the CloudFormation callback response.
+type cfnCapture struct {
+	Response CfResponse
+	server   *httptest.Server
+}
+
+func newCfnServer(t *testing.T) *cfnCapture {
+	t.Helper()
+	c := &cfnCapture{}
+	c.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer func() { _ = r.Body.Close() }()
+		_ = json.NewDecoder(r.Body).Decode(&c.Response)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(c.server.Close)
+	return c
+}
+
+func newTestHandler(cfnURL, configURL string) Handler {
+	return Handler{
+		Logger:            logr.Discard(),
+		ObserveAccountID:  "111222333",
+		ObserveDomainName: "observeinc.com",
+		WorkspaceID:       "ws-42",
+		Region:            "us-east-1",
+		AWSAccountID:      "999888777",
+		ExternalRoleName:  "observe-role",
+		PollerConfigURI:   configURL,
+	}
+}
+
+func newTestRequest(cfnURL string) *Request {
+	return &Request{
+		RequestType:       "Create",
+		ResponseURL:       cfnURL,
+		StackId:           "arn:aws:cloudformation:us-east-1:123:stack/test/guid",
+		RequestId:         "req-1",
+		LogicalResourceId: "PollerCustomResource",
+	}
+}
+
+func TestHandleCreate(t *testing.T) {
+	configServer := newConfigServer(t)
+	defer configServer.Close()
+
+	cfn := newCfnServer(t)
+	h := newTestHandler(cfn.server.URL, configServer.URL)
+
+	var capturedQuery string
+	gql := &gqlClient{
+		httpClient: &http.Client{Transport: &mockRoundTripper{
+			RoundTripFunc: func(req *http.Request) (*http.Response, error) {
+				body, _ := io.ReadAll(req.Body)
+				var gqlReq graphQLRequest
+				_ = json.Unmarshal(body, &gqlReq)
+				capturedQuery = gqlReq.Query
+				resp := `{"data":{"createPoller":{"id":"poller-abc","name":"test"}}}`
+				return &http.Response{
+					StatusCode: 200,
+					Body:       io.NopCloser(bytes.NewBufferString(resp)),
+				}, nil
+			},
+		}},
+		observeAccountID:  h.ObserveAccountID,
+		observeDomainName: h.ObserveDomainName,
+		logger:            logr.Discard(),
+	}
+
+	token := "test-token"
+	req := newTestRequest(cfn.server.URL)
+	req.RequestType = "Create"
+	assumeRoleArn := fmt.Sprintf("arn:aws:iam::%s:role/%s", h.AWSAccountID, h.ExternalRoleName)
+
+	_, err := h.handleCreate(context.Background(), req, gql, &token, assumeRoleArn)
+	if err != nil {
+		t.Fatalf("handleCreate() error = %v", err)
+	}
+
+	for _, want := range []string{
+		`createPoller`,
+		`workspaceId: "ws-42"`,
+		fmt.Sprintf(`name: "test-poller-%s-%s"`, h.AWSAccountID, h.Region),
+		`datastreamId: "ds-999"`,
+		`region: "us-east-1"`,
+		`assumeRoleArn: "arn:aws:iam::999888777:role/observe-role"`,
+		`namespace: "AWS/EC2"`,
+		`metricNames: ["CPUUtilization"]`,
+	} {
+		if !strings.Contains(capturedQuery, want) {
+			t.Errorf("createPoller mutation missing %q\ngot: %s", want, capturedQuery)
+		}
+	}
+
+	if cfn.Response.Status != "SUCCESS" {
+		t.Errorf("CFN status = %q, want SUCCESS", cfn.Response.Status)
+	}
+	if cfn.Response.PhysicalResourceId != "poller-abc" {
+		t.Errorf("CFN PhysicalResourceId = %q, want %q", cfn.Response.PhysicalResourceId, "poller-abc")
+	}
+}
+
+func TestHandleUpdate(t *testing.T) {
+	configServer := newConfigServer(t)
+	defer configServer.Close()
+
+	cfn := newCfnServer(t)
+	h := newTestHandler(cfn.server.URL, configServer.URL)
+
+	var capturedQuery string
+	gql := &gqlClient{
+		httpClient: &http.Client{Transport: &mockRoundTripper{
+			RoundTripFunc: func(req *http.Request) (*http.Response, error) {
+				body, _ := io.ReadAll(req.Body)
+				var gqlReq graphQLRequest
+				_ = json.Unmarshal(body, &gqlReq)
+				capturedQuery = gqlReq.Query
+				resp := `{"data":{"updatePoller":{"id":"existing-poller-id","name":"updated"}}}`
+				return &http.Response{
+					StatusCode: 200,
+					Body:       io.NopCloser(bytes.NewBufferString(resp)),
+				}, nil
+			},
+		}},
+		observeAccountID:  h.ObserveAccountID,
+		observeDomainName: h.ObserveDomainName,
+		logger:            logr.Discard(),
+	}
+
+	token := "test-token"
+	req := newTestRequest(cfn.server.URL)
+	req.RequestType = "Update"
+	req.PhysicalResourceId = "existing-poller-id"
+	assumeRoleArn := fmt.Sprintf("arn:aws:iam::%s:role/%s", h.AWSAccountID, h.ExternalRoleName)
+
+	_, err := h.handleUpdate(context.Background(), req, gql, &token, assumeRoleArn)
+	if err != nil {
+		t.Fatalf("handleUpdate() error = %v", err)
+	}
+
+	for _, want := range []string{
+		`updatePoller`,
+		`id: "existing-poller-id"`,
+		fmt.Sprintf(`name: "test-poller-%s-%s"`, h.AWSAccountID, h.Region),
+		`datastreamId: "ds-999"`,
+		`region: "us-east-1"`,
+	} {
+		if !strings.Contains(capturedQuery, want) {
+			t.Errorf("updatePoller mutation missing %q\ngot: %s", want, capturedQuery)
+		}
+	}
+
+	if cfn.Response.Status != "SUCCESS" {
+		t.Errorf("CFN status = %q, want SUCCESS", cfn.Response.Status)
+	}
+	if cfn.Response.PhysicalResourceId != "existing-poller-id" {
+		t.Errorf("CFN PhysicalResourceId = %q, want %q", cfn.Response.PhysicalResourceId, "existing-poller-id")
+	}
+}
+
+func TestHandleUpdate_MissingPhysicalResourceId(t *testing.T) {
+	cfn := newCfnServer(t)
+	h := newTestHandler(cfn.server.URL, "http://unused")
+
+	gqlCalled := false
+	gql := &gqlClient{
+		httpClient: &http.Client{Transport: &mockRoundTripper{
+			RoundTripFunc: func(req *http.Request) (*http.Response, error) {
+				gqlCalled = true
+				return &http.Response{StatusCode: 200, Body: io.NopCloser(bytes.NewBufferString(`{}`))}, nil
+			},
+		}},
+		logger: logr.Discard(),
+	}
+
+	token := "test-token"
+	req := newTestRequest(cfn.server.URL)
+	req.RequestType = "Update"
+	req.PhysicalResourceId = ""
+
+	_, err := h.handleUpdate(context.Background(), req, gql, &token, "arn:unused")
+	if err == nil {
+		t.Fatal("handleUpdate() should error when PhysicalResourceId is empty")
+	}
+
+	if gqlCalled {
+		t.Error("GQL should not be called when PhysicalResourceId is missing")
+	}
+	if cfn.Response.Status != "FAILED" {
+		t.Errorf("CFN status = %q, want FAILED", cfn.Response.Status)
+	}
+}
+
+func TestHandleDelete(t *testing.T) {
+	cfn := newCfnServer(t)
+	h := newTestHandler(cfn.server.URL, "http://unused")
+
+	var capturedQuery string
+	gql := &gqlClient{
+		httpClient: &http.Client{Transport: &mockRoundTripper{
+			RoundTripFunc: func(req *http.Request) (*http.Response, error) {
+				body, _ := io.ReadAll(req.Body)
+				var gqlReq graphQLRequest
+				_ = json.Unmarshal(body, &gqlReq)
+				capturedQuery = gqlReq.Query
+				resp := `{"data":{"deletePoller":{"success":true}}}`
+				return &http.Response{
+					StatusCode: 200,
+					Body:       io.NopCloser(bytes.NewBufferString(resp)),
+				}, nil
+			},
+		}},
+		observeAccountID:  h.ObserveAccountID,
+		observeDomainName: h.ObserveDomainName,
+		logger:            logr.Discard(),
+	}
+
+	token := "test-token"
+	req := newTestRequest(cfn.server.URL)
+	req.RequestType = "Delete"
+	req.PhysicalResourceId = "poller-to-delete"
+
+	_, err := h.handleDelete(req, gql, &token)
+	if err != nil {
+		t.Fatalf("handleDelete() error = %v", err)
+	}
+
+	for _, want := range []string{
+		`deletePoller`,
+		`id: "poller-to-delete"`,
+	} {
+		if !strings.Contains(capturedQuery, want) {
+			t.Errorf("deletePoller mutation missing %q\ngot: %s", want, capturedQuery)
+		}
+	}
+
+	if cfn.Response.Status != "SUCCESS" {
+		t.Errorf("CFN status = %q, want SUCCESS", cfn.Response.Status)
+	}
+}
+
+func TestHandleDelete_NoPhysicalResourceId(t *testing.T) {
+	cfn := newCfnServer(t)
+	h := newTestHandler(cfn.server.URL, "http://unused")
+
+	gqlCalled := false
+	gql := &gqlClient{
+		httpClient: &http.Client{Transport: &mockRoundTripper{
+			RoundTripFunc: func(req *http.Request) (*http.Response, error) {
+				gqlCalled = true
+				return &http.Response{StatusCode: 200, Body: io.NopCloser(bytes.NewBufferString(`{}`))}, nil
+			},
+		}},
+		logger: logr.Discard(),
+	}
+
+	token := "test-token"
+	req := newTestRequest(cfn.server.URL)
+	req.RequestType = "Delete"
+	req.PhysicalResourceId = ""
+
+	_, err := h.handleDelete(req, gql, &token)
+	if err != nil {
+		t.Fatalf("handleDelete() error = %v", err)
+	}
+
+	if gqlCalled {
+		t.Error("GQL should not be called when deleting with no PhysicalResourceId")
+	}
+	if cfn.Response.Status != "SUCCESS" {
+		t.Errorf("CFN status = %q, want SUCCESS (no-op delete)", cfn.Response.Status)
+	}
+}
+
+func TestHandleDelete_GQLError_StillReportsSuccess(t *testing.T) {
+	cfn := newCfnServer(t)
+	h := newTestHandler(cfn.server.URL, "http://unused")
+
+	gql := &gqlClient{
+		httpClient: &http.Client{Transport: &mockRoundTripper{
+			RoundTripFunc: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: 500,
+					Body:       io.NopCloser(bytes.NewBufferString("internal error")),
+				}, nil
+			},
+		}},
+		observeAccountID:  h.ObserveAccountID,
+		observeDomainName: h.ObserveDomainName,
+		logger:            logr.Discard(),
+	}
+
+	token := "test-token"
+	req := newTestRequest(cfn.server.URL)
+	req.RequestType = "Delete"
+	req.PhysicalResourceId = "poller-xyz"
+
+	_, err := h.handleDelete(req, gql, &token)
+	if err != nil {
+		t.Fatalf("handleDelete() error = %v", err)
+	}
+
+	if cfn.Response.Status != "SUCCESS" {
+		t.Errorf("CFN status = %q, want SUCCESS even when GQL fails", cfn.Response.Status)
+	}
+}
+
+func TestHandlerNew(t *testing.T) {
+	cfg := &Config{
+		ObserveAccountID:  "123",
+		ObserveDomainName: "observeinc.com",
+		SecretName:        "secret",
+		PollerConfigURI:   "s3://bucket/config.json",
+		ExternalRoleName:  "observe-role",
+		WorkspaceID:       "456",
+		Region:            "us-east-1",
+		AWSAccountID:      "999888777",
+	}
+
+	h, err := New(cfg, logr.Discard())
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	if h.ObserveAccountID != "123" {
+		t.Errorf("ObserveAccountID = %q, want %q", h.ObserveAccountID, "123")
+	}
+	if h.WorkspaceID != "456" {
+		t.Errorf("WorkspaceID = %q, want %q", h.WorkspaceID, "456")
+	}
+	if h.AWSAccountID != "999888777" {
+		t.Errorf("AWSAccountID = %q, want %q", h.AWSAccountID, "999888777")
+	}
+}

--- a/pkg/handler/pollerconfigurator/handler_test.go
+++ b/pkg/handler/pollerconfigurator/handler_test.go
@@ -8,9 +8,9 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/go-logr/logr"
 )
 
@@ -34,7 +34,6 @@ const testPollerConfig = `{
 	"queries": [{"namespace": "AWS/EC2", "metricNames": ["CPUUtilization"]}]
 }`
 
-// newConfigServer returns an httptest server that serves a valid poller config.
 func newConfigServer(t *testing.T) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -43,7 +42,6 @@ func newConfigServer(t *testing.T) *httptest.Server {
 	}))
 }
 
-// cfnCapture tracks the CloudFormation callback response.
 type cfnCapture struct {
 	Response CfResponse
 	server   *httptest.Server
@@ -84,6 +82,12 @@ func newTestRequest(cfnURL string) *Request {
 	}
 }
 
+// capturedGQLRequest holds both the query and variables from an intercepted request.
+type capturedGQLRequest struct {
+	Query     string                 `json:"query"`
+	Variables map[string]interface{} `json:"variables"`
+}
+
 func TestHandleCreate(t *testing.T) {
 	configServer := newConfigServer(t)
 	defer configServer.Close()
@@ -91,14 +95,12 @@ func TestHandleCreate(t *testing.T) {
 	cfn := newCfnServer(t)
 	h := newTestHandler(cfn.server.URL, configServer.URL)
 
-	var capturedQuery string
+	var captured capturedGQLRequest
 	gql := &gqlClient{
 		httpClient: &http.Client{Transport: &mockRoundTripper{
 			RoundTripFunc: func(req *http.Request) (*http.Response, error) {
 				body, _ := io.ReadAll(req.Body)
-				var gqlReq graphQLRequest
-				_ = json.Unmarshal(body, &gqlReq)
-				capturedQuery = gqlReq.Query
+				_ = json.Unmarshal(body, &captured)
 				resp := `{"data":{"createPoller":{"id":"poller-abc","name":"test"}}}`
 				return &http.Response{
 					StatusCode: 200,
@@ -116,25 +118,34 @@ func TestHandleCreate(t *testing.T) {
 	req.RequestType = "Create"
 	assumeRoleArn := fmt.Sprintf("arn:aws:iam::%s:role/%s", h.AWSAccountID, h.ExternalRoleName)
 
-	_, err := h.handleCreate(context.Background(), req, gql, &token, assumeRoleArn)
+	_, err := h.handleCreate(context.Background(), req, gql, &token, assumeRoleArn, aws.Config{})
 	if err != nil {
 		t.Fatalf("handleCreate() error = %v", err)
 	}
 
-	for _, want := range []string{
-		`createPoller`,
-		`workspaceId: "ws-42"`,
-		fmt.Sprintf(`name: "test-poller-%s-%s"`, h.AWSAccountID, h.Region),
-		`datastreamId: "ds-999"`,
-		`region: "us-east-1"`,
-		`assumeRoleArn: "arn:aws:iam::999888777:role/observe-role"`,
-		`namespace: "AWS/EC2"`,
-		`metricNames: ["CPUUtilization"]`,
-	} {
-		if !strings.Contains(capturedQuery, want) {
-			t.Errorf("createPoller mutation missing %q\ngot: %s", want, capturedQuery)
-		}
+	if captured.Query != createPollerMutation {
+		t.Errorf("query = %q, want createPollerMutation", captured.Query)
 	}
+
+	assertMapField(t, captured.Variables, "workspaceId", "ws-42")
+
+	poller := variableAsMap(t, captured.Variables, "poller")
+	wantName := fmt.Sprintf("test-poller-%s-%s", h.AWSAccountID, h.Region)
+	assertMapField(t, poller, "name", wantName)
+	assertMapField(t, poller, "datastreamId", "ds-999")
+
+	cw := poller["cloudWatchMetricsConfig"].(map[string]interface{})
+	assertMapField(t, cw, "period", "300")
+	assertMapField(t, cw, "delay", "300")
+	assertMapField(t, cw, "region", "us-east-1")
+	assertMapField(t, cw, "assumeRoleArn", "arn:aws:iam::999888777:role/observe-role")
+
+	queries := cw["queries"].([]interface{})
+	if len(queries) != 1 {
+		t.Fatalf("got %d queries, want 1", len(queries))
+	}
+	q := queries[0].(map[string]interface{})
+	assertMapField(t, q, "namespace", "AWS/EC2")
 
 	if cfn.Response.Status != "SUCCESS" {
 		t.Errorf("CFN status = %q, want SUCCESS", cfn.Response.Status)
@@ -151,14 +162,12 @@ func TestHandleUpdate(t *testing.T) {
 	cfn := newCfnServer(t)
 	h := newTestHandler(cfn.server.URL, configServer.URL)
 
-	var capturedQuery string
+	var captured capturedGQLRequest
 	gql := &gqlClient{
 		httpClient: &http.Client{Transport: &mockRoundTripper{
 			RoundTripFunc: func(req *http.Request) (*http.Response, error) {
 				body, _ := io.ReadAll(req.Body)
-				var gqlReq graphQLRequest
-				_ = json.Unmarshal(body, &gqlReq)
-				capturedQuery = gqlReq.Query
+				_ = json.Unmarshal(body, &captured)
 				resp := `{"data":{"updatePoller":{"id":"existing-poller-id","name":"updated"}}}`
 				return &http.Response{
 					StatusCode: 200,
@@ -177,22 +186,24 @@ func TestHandleUpdate(t *testing.T) {
 	req.PhysicalResourceId = "existing-poller-id"
 	assumeRoleArn := fmt.Sprintf("arn:aws:iam::%s:role/%s", h.AWSAccountID, h.ExternalRoleName)
 
-	_, err := h.handleUpdate(context.Background(), req, gql, &token, assumeRoleArn)
+	_, err := h.handleUpdate(context.Background(), req, gql, &token, assumeRoleArn, aws.Config{})
 	if err != nil {
 		t.Fatalf("handleUpdate() error = %v", err)
 	}
 
-	for _, want := range []string{
-		`updatePoller`,
-		`id: "existing-poller-id"`,
-		fmt.Sprintf(`name: "test-poller-%s-%s"`, h.AWSAccountID, h.Region),
-		`datastreamId: "ds-999"`,
-		`region: "us-east-1"`,
-	} {
-		if !strings.Contains(capturedQuery, want) {
-			t.Errorf("updatePoller mutation missing %q\ngot: %s", want, capturedQuery)
-		}
+	if captured.Query != updatePollerMutation {
+		t.Errorf("query = %q, want updatePollerMutation", captured.Query)
 	}
+
+	assertMapField(t, captured.Variables, "id", "existing-poller-id")
+
+	poller := variableAsMap(t, captured.Variables, "poller")
+	wantName := fmt.Sprintf("test-poller-%s-%s", h.AWSAccountID, h.Region)
+	assertMapField(t, poller, "name", wantName)
+	assertMapField(t, poller, "datastreamId", "ds-999")
+
+	cw := poller["cloudWatchMetricsConfig"].(map[string]interface{})
+	assertMapField(t, cw, "region", "us-east-1")
 
 	if cfn.Response.Status != "SUCCESS" {
 		t.Errorf("CFN status = %q, want SUCCESS", cfn.Response.Status)
@@ -222,7 +233,7 @@ func TestHandleUpdate_MissingPhysicalResourceId(t *testing.T) {
 	req.RequestType = "Update"
 	req.PhysicalResourceId = ""
 
-	_, err := h.handleUpdate(context.Background(), req, gql, &token, "arn:unused")
+	_, err := h.handleUpdate(context.Background(), req, gql, &token, "arn:unused", aws.Config{})
 	if err == nil {
 		t.Fatal("handleUpdate() should error when PhysicalResourceId is empty")
 	}
@@ -239,14 +250,12 @@ func TestHandleDelete(t *testing.T) {
 	cfn := newCfnServer(t)
 	h := newTestHandler(cfn.server.URL, "http://unused")
 
-	var capturedQuery string
+	var captured capturedGQLRequest
 	gql := &gqlClient{
 		httpClient: &http.Client{Transport: &mockRoundTripper{
 			RoundTripFunc: func(req *http.Request) (*http.Response, error) {
 				body, _ := io.ReadAll(req.Body)
-				var gqlReq graphQLRequest
-				_ = json.Unmarshal(body, &gqlReq)
-				capturedQuery = gqlReq.Query
+				_ = json.Unmarshal(body, &captured)
 				resp := `{"data":{"deletePoller":{"success":true}}}`
 				return &http.Response{
 					StatusCode: 200,
@@ -269,14 +278,10 @@ func TestHandleDelete(t *testing.T) {
 		t.Fatalf("handleDelete() error = %v", err)
 	}
 
-	for _, want := range []string{
-		`deletePoller`,
-		`id: "poller-to-delete"`,
-	} {
-		if !strings.Contains(capturedQuery, want) {
-			t.Errorf("deletePoller mutation missing %q\ngot: %s", want, capturedQuery)
-		}
+	if captured.Query != deletePollerMutation {
+		t.Errorf("query = %q, want deletePollerMutation", captured.Query)
 	}
+	assertMapField(t, captured.Variables, "id", "poller-to-delete")
 
 	if cfn.Response.Status != "SUCCESS" {
 		t.Errorf("CFN status = %q, want SUCCESS", cfn.Response.Status)
@@ -374,5 +379,30 @@ func TestHandlerNew(t *testing.T) {
 	}
 	if h.AWSAccountID != "999888777" {
 		t.Errorf("AWSAccountID = %q, want %q", h.AWSAccountID, "999888777")
+	}
+}
+
+func variableAsMap(t *testing.T, vars map[string]interface{}, key string) map[string]interface{} {
+	t.Helper()
+	v, ok := vars[key]
+	if !ok {
+		t.Fatalf("variables missing key %q", key)
+	}
+	m, ok := v.(map[string]interface{})
+	if !ok {
+		t.Fatalf("variables[%q] is %T, want map", key, v)
+	}
+	return m
+}
+
+func assertMapField(t *testing.T, m map[string]interface{}, key, want string) {
+	t.Helper()
+	got, ok := m[key]
+	if !ok {
+		t.Errorf("map missing key %q", key)
+		return
+	}
+	if fmt.Sprintf("%v", got) != want {
+		t.Errorf("map[%q] = %v, want %q", key, got, want)
 	}
 }

--- a/pkg/handler/pollerconfigurator/request.go
+++ b/pkg/handler/pollerconfigurator/request.go
@@ -1,0 +1,17 @@
+package pollerconfigurator
+
+type Request struct {
+	RequestId          string             `json:"RequestId"`
+	StackId            string             `json:"StackId"`
+	RequestType        string             `json:"RequestType"`
+	LogicalResourceId  string             `json:"LogicalResourceId"`
+	PhysicalResourceId string             `json:"PhysicalResourceId"`
+	ResourceProperties ResourceProperties `json:"ResourceProperties"`
+	ResourceType       string             `json:"ResourceType"`
+	ResponseURL        string             `json:"ResponseURL"`
+}
+
+type ResourceProperties struct {
+	ServiceToken string `json:"ServiceToken"`
+	StackName    string `json:"StackName"`
+}

--- a/pkg/handler/pollerconfigurator/response.go
+++ b/pkg/handler/pollerconfigurator/response.go
@@ -1,0 +1,11 @@
+package pollerconfigurator
+
+type CfResponse struct {
+	Status             string                 `json:"Status"`
+	Reason             string                 `json:"Reason,omitempty"`
+	PhysicalResourceId string                 `json:"PhysicalResourceId,omitempty"`
+	StackId            string                 `json:"StackId"`
+	RequestId          string                 `json:"RequestId"`
+	LogicalResourceId  string                 `json:"LogicalResourceId"`
+	Data               map[string]interface{} `json:"Data,omitempty"`
+}

--- a/pkg/handler/pollerconfigurator/s3config.go
+++ b/pkg/handler/pollerconfigurator/s3config.go
@@ -1,0 +1,113 @@
+package pollerconfigurator
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+type TagFilter struct {
+	Key    string   `json:"key"`
+	Values []string `json:"values,omitempty"`
+}
+
+type ResourceFilter struct {
+	ResourceType  string      `json:"resourceType,omitempty"`
+	Pattern       string      `json:"pattern,omitempty"`
+	DimensionName string      `json:"dimensionName,omitempty"`
+	TagFilters    []TagFilter `json:"tagFilters"`
+}
+
+type DimensionFilter struct {
+	Name  string `json:"name"`
+	Value string `json:"value,omitempty"`
+}
+
+type QueryConfig struct {
+	Namespace      string            `json:"namespace"`
+	MetricNames    []string          `json:"metricNames,omitempty"`
+	Dimensions     []DimensionFilter `json:"dimensions,omitempty"`
+	ResourceFilter *ResourceFilter   `json:"resourceFilter,omitempty"`
+}
+
+type PollerConfig struct {
+	Name         string        `json:"name"`
+	DatastreamId string        `json:"datastreamId"`
+	Period       int64         `json:"period"`
+	Delay        int64         `json:"delay"`
+	Interval     string        `json:"interval"`
+	Retries      *int64        `json:"retries,omitempty"`
+	Queries      []QueryConfig `json:"queries"`
+}
+
+func s3URIToHTTPS(uri string) (string, error) {
+	if !strings.HasPrefix(uri, "s3://") {
+		return "", fmt.Errorf("invalid S3 URI: must start with s3://")
+	}
+	path := strings.TrimPrefix(uri, "s3://")
+	parts := strings.SplitN(path, "/", 2)
+	if len(parts) < 2 || parts[1] == "" {
+		return "", fmt.Errorf("invalid S3 URI: must contain bucket and key")
+	}
+	return fmt.Sprintf("https://%s.s3.amazonaws.com/%s", parts[0], parts[1]), nil
+}
+
+func downloadPollerConfig(ctx context.Context, uri string) (*PollerConfig, error) {
+	// for testing purposes
+	if strings.HasPrefix(uri, "http://") || strings.HasPrefix(uri, "https://") {
+		return downloadPollerConfigFromURL(ctx, uri)
+	}
+	url, err := s3URIToHTTPS(uri)
+	if err != nil {
+		return nil, err
+	}
+	return downloadPollerConfigFromURL(ctx, url)
+}
+
+func downloadPollerConfigFromURL(ctx context.Context, url string) (*PollerConfig, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request for %s: %w", url, err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to download poller config from %s: %w", url, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to download poller config from %s: HTTP %d", url, resp.StatusCode)
+	}
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read poller config body: %w", err)
+	}
+
+	var cfg PollerConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("failed to parse poller config JSON: %w", err)
+	}
+
+	if len(cfg.Queries) == 0 {
+		return nil, fmt.Errorf("poller config must contain at least one query")
+	}
+	if cfg.Period <= 0 {
+		return nil, fmt.Errorf("poller config period must be positive")
+	}
+	if cfg.Delay <= 0 {
+		return nil, fmt.Errorf("poller config delay must be positive")
+	}
+	if cfg.DatastreamId == "" {
+		return nil, fmt.Errorf("poller config must include datastreamId")
+	}
+	if cfg.Interval == "" {
+		return nil, fmt.Errorf("poller config must include interval")
+	}
+
+	return &cfg, nil
+}

--- a/pkg/handler/pollerconfigurator/s3config.go
+++ b/pkg/handler/pollerconfigurator/s3config.go
@@ -7,6 +7,9 @@ import (
 	"io"
 	"net/http"
 	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
 )
 
 type TagFilter struct {
@@ -43,28 +46,43 @@ type PollerConfig struct {
 	Queries      []QueryConfig `json:"queries"`
 }
 
-func s3URIToHTTPS(uri string) (string, error) {
+func parseS3URI(uri string) (bucket, key string, err error) {
 	if !strings.HasPrefix(uri, "s3://") {
-		return "", fmt.Errorf("invalid S3 URI: must start with s3://")
+		return "", "", fmt.Errorf("invalid S3 URI: must start with s3://")
 	}
 	path := strings.TrimPrefix(uri, "s3://")
 	parts := strings.SplitN(path, "/", 2)
 	if len(parts) < 2 || parts[1] == "" {
-		return "", fmt.Errorf("invalid S3 URI: must contain bucket and key")
+		return "", "", fmt.Errorf("invalid S3 URI: must contain bucket and key")
 	}
-	return fmt.Sprintf("https://%s.s3.amazonaws.com/%s", parts[0], parts[1]), nil
+	return parts[0], parts[1], nil
 }
 
-func downloadPollerConfig(ctx context.Context, uri string) (*PollerConfig, error) {
-	// for testing purposes
+func downloadPollerConfig(ctx context.Context, uri string, awsCfg aws.Config) (*PollerConfig, error) {
+	// for testing: allow direct HTTP URLs so tests can use httptest servers
 	if strings.HasPrefix(uri, "http://") || strings.HasPrefix(uri, "https://") {
 		return downloadPollerConfigFromURL(ctx, uri)
 	}
-	url, err := s3URIToHTTPS(uri)
+
+	bucket, key, err := parseS3URI(uri)
 	if err != nil {
 		return nil, err
 	}
-	return downloadPollerConfigFromURL(ctx, url)
+	return downloadPollerConfigFromS3(ctx, awsCfg, bucket, key)
+}
+
+func downloadPollerConfigFromS3(ctx context.Context, awsCfg aws.Config, bucket, key string) (*PollerConfig, error) {
+	client := s3.NewFromConfig(awsCfg)
+	out, err := client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: &bucket,
+		Key:    &key,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get s3://%s/%s: %w", bucket, key, err)
+	}
+	defer func() { _ = out.Body.Close() }()
+
+	return parsePollerConfig(out.Body)
 }
 
 func downloadPollerConfigFromURL(ctx context.Context, url string) (*PollerConfig, error) {
@@ -83,7 +101,11 @@ func downloadPollerConfigFromURL(ctx context.Context, url string) (*PollerConfig
 		return nil, fmt.Errorf("failed to download poller config from %s: HTTP %d", url, resp.StatusCode)
 	}
 
-	data, err := io.ReadAll(resp.Body)
+	return parsePollerConfig(resp.Body)
+}
+
+func parsePollerConfig(r io.Reader) (*PollerConfig, error) {
+	data, err := io.ReadAll(r)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read poller config body: %w", err)
 	}

--- a/pkg/handler/pollerconfigurator/s3config_test.go
+++ b/pkg/handler/pollerconfigurator/s3config_test.go
@@ -1,0 +1,148 @@
+package pollerconfigurator
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestS3URIToHTTPS(t *testing.T) {
+	tests := []struct {
+		name    string
+		uri     string
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "valid URI",
+			uri:  "s3://my-bucket/path/to/config.json",
+			want: "https://my-bucket.s3.amazonaws.com/path/to/config.json",
+		},
+		{
+			name:    "missing s3 prefix",
+			uri:     "https://my-bucket/config.json",
+			wantErr: true,
+		},
+		{
+			name:    "no key",
+			uri:     "s3://my-bucket",
+			wantErr: true,
+		},
+		{
+			name:    "empty key",
+			uri:     "s3://my-bucket/",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := s3URIToHTTPS(tt.uri)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("s3URIToHTTPS() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("s3URIToHTTPS() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDownloadPollerConfig(t *testing.T) {
+	tests := []struct {
+		name       string
+		body       string
+		statusCode int
+		wantErr    bool
+		errSubstr  string
+		wantName   string
+		wantPeriod int64
+	}{
+		{
+			name:       "valid config",
+			body:       `{"name":"test-poller","datastreamId":"12345","interval":"5m","period":300,"delay":300,"queries":[{"namespace":"AWS/EC2"}]}`,
+			statusCode: http.StatusOK,
+			wantName:   "test-poller",
+			wantPeriod: 300,
+		},
+		{
+			name:       "missing queries",
+			body:       `{"name":"test-poller","datastreamId":"12345","interval":"5m","period":300,"delay":300,"queries":[]}`,
+			statusCode: http.StatusOK,
+			wantErr:    true,
+			errSubstr:  "at least one query",
+		},
+		{
+			name:       "zero period",
+			body:       `{"name":"test-poller","datastreamId":"12345","interval":"5m","period":0,"delay":300,"queries":[{"namespace":"AWS/EC2"}]}`,
+			statusCode: http.StatusOK,
+			wantErr:    true,
+			errSubstr:  "period must be positive",
+		},
+		{
+			name:       "zero delay",
+			body:       `{"name":"test-poller","datastreamId":"12345","interval":"5m","period":300,"delay":0,"queries":[{"namespace":"AWS/EC2"}]}`,
+			statusCode: http.StatusOK,
+			wantErr:    true,
+			errSubstr:  "delay must be positive",
+		},
+		{
+			name:       "missing datastreamId",
+			body:       `{"name":"test-poller","interval":"5m","period":300,"delay":300,"queries":[{"namespace":"AWS/EC2"}]}`,
+			statusCode: http.StatusOK,
+			wantErr:    true,
+			errSubstr:  "must include datastreamId",
+		},
+		{
+			name:       "missing interval",
+			body:       `{"name":"test-poller","datastreamId":"12345","period":300,"delay":300,"queries":[{"namespace":"AWS/EC2"}]}`,
+			statusCode: http.StatusOK,
+			wantErr:    true,
+			errSubstr:  "must include interval",
+		},
+		{
+			name:       "invalid JSON",
+			body:       `{invalid`,
+			statusCode: http.StatusOK,
+			wantErr:    true,
+			errSubstr:  "parse poller config JSON",
+		},
+		{
+			name:       "HTTP error",
+			body:       "not found",
+			statusCode: http.StatusNotFound,
+			wantErr:    true,
+			errSubstr:  "HTTP 404",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.statusCode)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer srv.Close()
+
+			cfg, err := downloadPollerConfigFromURL(context.Background(), srv.URL)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("downloadPollerConfig() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr && tt.errSubstr != "" && !strings.Contains(err.Error(), tt.errSubstr) {
+				t.Errorf("downloadPollerConfig() error = %q, want substr %q", err.Error(), tt.errSubstr)
+			}
+			if !tt.wantErr {
+				if cfg.Name != tt.wantName {
+					t.Errorf("cfg.Name = %q, want %q", cfg.Name, tt.wantName)
+				}
+				if cfg.Period != tt.wantPeriod {
+					t.Errorf("cfg.Period = %d, want %d", cfg.Period, tt.wantPeriod)
+				}
+			}
+		})
+	}
+}

--- a/pkg/handler/pollerconfigurator/s3config_test.go
+++ b/pkg/handler/pollerconfigurator/s3config_test.go
@@ -8,17 +8,19 @@ import (
 	"testing"
 )
 
-func TestS3URIToHTTPS(t *testing.T) {
+func TestParseS3URI(t *testing.T) {
 	tests := []struct {
-		name    string
-		uri     string
-		want    string
-		wantErr bool
+		name       string
+		uri        string
+		wantBucket string
+		wantKey    string
+		wantErr    bool
 	}{
 		{
-			name: "valid URI",
-			uri:  "s3://my-bucket/path/to/config.json",
-			want: "https://my-bucket.s3.amazonaws.com/path/to/config.json",
+			name:       "valid URI",
+			uri:        "s3://my-bucket/path/to/config.json",
+			wantBucket: "my-bucket",
+			wantKey:    "path/to/config.json",
 		},
 		{
 			name:    "missing s3 prefix",
@@ -39,13 +41,16 @@ func TestS3URIToHTTPS(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := s3URIToHTTPS(tt.uri)
+			bucket, key, err := parseS3URI(tt.uri)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("s3URIToHTTPS() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("parseS3URI() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if got != tt.want {
-				t.Errorf("s3URIToHTTPS() = %q, want %q", got, tt.want)
+			if bucket != tt.wantBucket {
+				t.Errorf("parseS3URI() bucket = %q, want %q", bucket, tt.wantBucket)
+			}
+			if key != tt.wantKey {
+				t.Errorf("parseS3URI() key = %q, want %q", key, tt.wantKey)
 			}
 		})
 	}

--- a/pkg/lambda/pollerconfigurator/lambda.go
+++ b/pkg/lambda/pollerconfigurator/lambda.go
@@ -1,0 +1,37 @@
+package pollerconfigurator
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/go-logr/logr"
+	"github.com/observeinc/aws-sam-apps/pkg/handler/pollerconfigurator"
+	"github.com/observeinc/aws-sam-apps/pkg/logging"
+)
+
+type Lambda struct {
+	Logger     logr.Logger
+	Entrypoint lambda.Handler
+	Shutdown   func()
+}
+
+func New(ctx context.Context, cfg *pollerconfigurator.Config) (*Lambda, error) {
+	logger := logging.New(cfg.Logging)
+	logger.V(4).Info("initialized", "config", cfg)
+
+	l := &Lambda{
+		Logger: logger,
+		Shutdown: func() {
+			logger.V(4).Info("SIGTERM received, running shutdown")
+		},
+	}
+
+	handler, err := pollerconfigurator.New(cfg, logger)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create handler: %w", err)
+	}
+
+	l.Entrypoint = handler
+	return l, nil
+}

--- a/variables.mk
+++ b/variables.mk
@@ -40,7 +40,7 @@ OS              := $(if $(GOOS),$(GOOS),linux)
 ARCH            := $(if $(GOARCH),$(GOARCH),arm64)
 
 # Names of binaries to compile as lambda functions
-GO_BINS         := forwarder subscriber metricsconfigurator
+GO_BINS         := forwarder subscriber metricsconfigurator pollerconfigurator
 # Directories that we need created to build/test.
 GO_BUILD_DIRS   := bin/$(OS)_$(ARCH)                   \
                 .go/bin/$(OS)_$(ARCH)               \


### PR DESCRIPTION
## Summary

- Adds a new `pollerconfigurator` Lambda function that manages CloudWatch Metrics poller lifecycle in the Observe backend via the GQL API.
- Used as a CloudFormation custom resource to create, update, and delete pollers when stacks are deployed across an organization.
- Includes comprehensive unit tests for GQL mutation building, handler logic, S3 config download, and CFN response reporting.

This is the first in a sequence of PRs extracted from #444 (add-stacksets). Each PR in the chain is independently releasable.

## What's included

- `cmd/pollerconfigurator/main.go` — Lambda entry point
- `pkg/handler/pollerconfigurator/` — handler, GQL client, config types, S3 config downloader, CFN request/response types
- `pkg/lambda/pollerconfigurator/lambda.go` — Lambda wrapper
- `variables.mk` / `Dockerfile.all-binaries` — build pipeline additions (additive only)

## What's NOT included

- No new SAM app template — the binary gets built but is not yet referenced by any CloudFormation template
- `.gitignore` changes deferred to a later PR in the chain

## Test plan

- [x] Cherry-picks cleanly onto current `main`
- [x] `go build ./...` succeeds
- [x] `go vet` passes
- [x] All 19 new tests pass (`go test ./pkg/handler/pollerconfigurator/...`)
- [x] All existing tests still pass (`go test ./...`)
- [ ] CI passes (lint, test, sam-validate, upload, integration)

Made with [Cursor](https://cursor.com)