### PR TITLE
fix: ALB logs fail to decode when HTTPS destination due to missing gzip content-encoding

### DIFF
--- a/pkg/handler/forwarder/override/presets/aws/v1.yaml
+++ b/pkg/handler/forwarder/override/presets/aws/v1.yaml
@@ -54,7 +54,7 @@
 
 - id: elasticLoadBalancing
   match:
-    source: '\d{12}_elasticloadbalancing_[a-z\d-]+_[a-zA-Z0-9-]+_\d{8}T\d{4}Z_[0-9.]+_[a-zA-Z0-9]+\.log\.gz$'
+    source: '\d{12}_elasticloadbalancing_[a-z\d-]+_[a-zA-Z0-9.-]+_\d{8}T\d{4}Z_[0-9.]+_[a-zA-Z0-9]+\.log\.gz$'
   override:
     content-type: 'application/x-aws-elasticloadbalancing'
     content-encoding: 'gzip'

--- a/pkg/handler/forwarder/s3http/client.go
+++ b/pkg/handler/forwarder/s3http/client.go
@@ -150,6 +150,14 @@ func (c *Client) CopyObject(ctx context.Context, params *s3.CopyObjectInput, opt
 
 	putInput := toPutInput(params, seekableBody, getResp.ContentType, getResp.ContentEncoding)
 
+	// Infer content-encoding for gzip files when not already set by override rules.
+	// This handles the case where a custom override sets content-type but not content-encoding,
+	// causing Sets.Apply to stop before infer/v1's gzip rule can run.
+	// We check the source key (getInput.Key) since the destination key may differ or lack the .gz suffix.
+	if aws.ToString(putInput.ContentEncoding) == "" && strings.HasSuffix(aws.ToString(getInput.Key), ".gz") {
+		putInput.ContentEncoding = aws.String("gzip")
+	}
+
 	putResp, err := c.PutObject(ctx, putInput, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to put object: %w", err)

--- a/pkg/handler/forwarder/s3http/client_test.go
+++ b/pkg/handler/forwarder/s3http/client_test.go
@@ -2,8 +2,10 @@ package s3http_test
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -112,5 +114,102 @@ func TestClientPut(t *testing.T) {
 				t.Fatal("response does not match", diff)
 			}
 		})
+	}
+}
+
+// TestCopyObjectGzipInference verifies that when a custom content-type override sets
+// "application/x-aws-elasticloadbalancing" but leaves content-encoding nil, CopyObject
+// still correctly infers "gzip" from the ".gz" key suffix and decompresses the body.
+func TestCopyObjectGzipInference(t *testing.T) {
+	t.Parallel()
+
+	// Build a gzip-compressed body containing two SSV lines:
+	// line 1: header (space-separated field names)
+	// line 2: a single ALB-like log record
+	const (
+		header = "type time elb client:port target:port request_processing_time"
+		record = `https 2024-01-01T00:00:00.000000Z my-alb 1.2.3.4:1234 10.0.0.1:80 0.001`
+	)
+
+	var gzBuf bytes.Buffer
+	gw := gzip.NewWriter(&gzBuf)
+	if _, err := io.WriteString(gw, header+"\n"+record+"\n"); err != nil {
+		t.Fatal(err)
+	}
+	if err := gw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	gzBytes := gzBuf.Bytes()
+
+	// Capture requests sent to the HTTP destination.
+	var (
+		mu      sync.Mutex
+		reqBody bytes.Buffer
+	)
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		body, _ := io.ReadAll(r.Body)
+		reqBody.Write(body)
+	}))
+	defer srv.Close()
+
+	// Mock S3 client: returns our gzip body with content-type set but NO content-encoding.
+	mockS3 := &awstest.S3Client{
+		GetObjectFunc: func(_ context.Context, _ *s3.GetObjectInput, _ ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+			size := int64(len(gzBytes))
+			return &s3.GetObjectOutput{
+				Body:            io.NopCloser(bytes.NewReader(gzBytes)),
+				ContentLength:   &size,
+				ContentType:     aws.String("application/x-aws-elasticloadbalancing"),
+				ContentEncoding: nil, // simulates override setting type but not encoding
+			}, nil
+		},
+	}
+
+	client, err := s3http.New(&s3http.Config{
+		DestinationURI:     srv.URL,
+		GetObjectAPIClient: mockS3,
+		HTTPClient:         srv.Client(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = client.CopyObject(context.Background(), &s3.CopyObjectInput{
+		Bucket:          aws.String("dst-bucket"),
+		Key:             aws.String("output/alb.log"),
+		CopySource:      aws.String("src-bucket/logs/alb-2024-01-01.log.gz"),
+		ContentType:     aws.String("application/x-aws-elasticloadbalancing"),
+		ContentEncoding: nil,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := reqBody.String()
+	t.Logf("received body:\n%s", got)
+
+	// The decoded output should contain the SSV-decoded JSON record, not raw binary.
+	// Verify no raw gzip magic bytes leaked through.
+	if strings.Contains(got, "\x1f\x8b") {
+		t.Fatal("response body contains raw gzip magic bytes — gzip was not decompressed")
+	}
+
+	// Verify the decoded record fields appear as JSON keys/values.
+	for _, want := range []string{`"type"`, `"https"`, `"elb"`, `"my-alb"`} {
+		if !strings.Contains(got, want) {
+			t.Errorf("expected %q in decoded output, got:\n%s", want, got)
+		}
+	}
+
+	// Ensure it's valid ndjson (each line should be a JSON object).
+	for _, line := range strings.Split(strings.TrimSpace(got), "\n") {
+		if line == "" {
+			continue
+		}
+		if !strings.HasPrefix(line, "{") || !strings.HasSuffix(line, "}") {
+			t.Errorf("line is not a JSON object: %q", line)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Fixes two issues that together cause AWS ALB access log files to fail
processing when `DESTINATION_URI` is an HTTPS endpoint.

Closes #459

## Changes

### 1. `pkg/handler/forwarder/override/presets/aws/v1.yaml`

Fix the `elasticLoadBalancing` preset regex to allow dots in the load
balancer name segment. ALB log filenames embed the ARN path as
`app.<alb-name>.<hexid>` (dots), but the previous character class
`[a-zA-Z0-9-]+` excluded dots, so the preset silently never matched
any ALB log file.

### 2. `pkg/handler/forwarder/s3http/client.go`

In `CopyObject`, infer `content-encoding: gzip` for `.gz` source keys
when `ContentEncoding` is not already set after override rules have run.

This handles the case where a `CONTENT_TYPE_OVERRIDES` rule sets
`content-type` (e.g. `application/x-aws-elasticloadbalancing`) but not
`content-encoding`. Because `Sets.Apply` stops at the first matching
set, `infer/v1`'s gzip rule never gets a chance to run — leaving
`ContentEncoding` empty. Without a gzip wrapper, the decoder receives
raw compressed bytes and produces garbage output or errors.

The check uses `getInput.Key` (the source object key) since the
destination key may differ and may not carry the `.gz` suffix.

## Testing

- Added `TestCopyObjectGzipInference` to `client_test.go`: creates a
  gzip-compressed ALB log body, mocks S3 `GetObject` returning it with
  `ContentType` set but `ContentEncoding: nil`, calls `CopyObject`, and
  asserts the HTTP destination receives decoded NDJSON (not raw binary).
- All existing tests pass: `TestClientPut`, `TestDecoders`.
