### PR TITLE
fix(logwriter): make default FilterName unique per stack and scope integration-test patterns

### DIFF
--- a/apps/logwriter/template.yaml
+++ b/apps/logwriter/template.yaml
@@ -90,7 +90,10 @@ Parameters:
     Type: String
     Description: >-
       Subscription filter name. Existing filters that have this name as a
-      prefix will be removed.
+      prefix will be removed. If unset, defaults to
+      "observe-logs-subscription-" suffixed with NameOverride so each stack
+      owns a uniquely-named filter and stacks do not contend for ownership of
+      the same subscription filter on shared log groups.
     Default: ''
   FilterPattern:
     Type: String
@@ -455,7 +458,7 @@ Resources:
         Variables:
           FILTER_NAME: !If
             - UseDefaultFilterName
-            - 'observe-logs-subscription'
+            - !Sub 'observe-logs-subscription-${NameOverride}'
             - !Ref FilterName
           FILTER_PATTERN: !Ref FilterPattern
           DESTINATION_ARN: !GetAtt DeliveryStream.Arn

--- a/apps/stack/template.yaml
+++ b/apps/stack/template.yaml
@@ -461,7 +461,6 @@ Resources:
         ExcludeLogGroupNamePatterns: !Join
           - ","
           - !Ref ExcludeLogGroupNamePatterns
-        FilterName: 'observe-logs-subscription'
         DiscoveryRate: "24 hours"
         NameOverride: !If
           - UseStackName

--- a/integration/tests/logwriter.tftest.hcl
+++ b/integration/tests/logwriter.tftest.hcl
@@ -115,7 +115,7 @@ run "install" {
     app   = "logwriter"
     parameters = {
       BucketArn            = run.create_bucket.arn
-      LogGroupNamePatterns = "*"
+      LogGroupNamePatterns = run.setup.id
       DiscoveryRate        = "24 hours"
       NameOverride         = run.setup.id
       Verbosity            = 3
@@ -152,7 +152,7 @@ run "update" {
     app   = "logwriter"
     parameters = {
       BucketArn            = run.create_bucket.arn
-      LogGroupNamePatterns = "*"
+      LogGroupNamePatterns = run.setup.id
       DiscoveryRate        = "24 hours"
       NameOverride         = run.setup.id
       Verbosity            = 4

--- a/integration/tests/stack.tftest.hcl
+++ b/integration/tests/stack.tftest.hcl
@@ -190,7 +190,7 @@ run "install" {
       DestinationUri           = "s3://${run.create_bucket.access_point.alias}/"
       ConfigDeliveryBucketName = "example-bucket"
       SourceBucketNames        = "*"
-      LogGroupNamePatterns     = "*"
+      LogGroupNamePatterns     = run.setup.id
       NameOverride             = run.setup.id
     }
     capabilities = [

--- a/integration/tests/stack_including_metricspollerrole.tftest.hcl
+++ b/integration/tests/stack_including_metricspollerrole.tftest.hcl
@@ -190,7 +190,7 @@ run "install" {
       DestinationUri           = "s3://${run.create_bucket.access_point.alias}/"
       ConfigDeliveryBucketName = "example-bucket"
       SourceBucketNames        = "*"
-      LogGroupNamePatterns     = "*"
+      LogGroupNamePatterns     = run.setup.id
       ObserveAwsAccountId = "158067661102"
       DatastreamIds       = "411000001"
       NameOverride             = run.setup.id

--- a/integration/tests/stack_with_org_id.tftest.hcl
+++ b/integration/tests/stack_with_org_id.tftest.hcl
@@ -197,7 +197,7 @@ run "install_with_org_id" {
       DestinationUri           = "s3://${run.create_bucket.access_point.alias}/"
       ConfigDeliveryBucketName = "example-bucket"
       SourceBucketNames        = "*"
-      LogGroupNamePatterns     = "*"
+      LogGroupNamePatterns     = run.setup.id
       OrgId                    = run.get_org_id.org_id
       NameOverride             = run.setup.id
     }

--- a/integration/tests/stack_with_source_accounts.tftest.hcl
+++ b/integration/tests/stack_with_source_accounts.tftest.hcl
@@ -200,7 +200,7 @@ run "install_with_source_accounts" {
       DestinationUri           = "s3://${run.create_bucket.access_point.alias}/"
       ConfigDeliveryBucketName = "example-bucket"
       SourceBucketNames        = "*"
-      LogGroupNamePatterns     = "*"
+      LogGroupNamePatterns     = run.setup.id
       SourceAccounts           = var.test_source_account_id
       NameOverride             = run.setup.id
     }


### PR DESCRIPTION
## Summary

- Default `FilterName` for the logwriter app now resolves to `observe-logs-subscription-${NameOverride}`, so each stack manages a uniquely-named subscription filter.
- Drop the redundant `FilterName: 'observe-logs-subscription'` override in the parent `apps/stack/template.yaml`, letting the new default flow through.
- Scope integration tests (`logwriter`, `stack`, `stack_with_org_id`, `stack_with_source_accounts`, `stack_including_metricspollerrole`) from `LogGroupNamePatterns = "*"` to `LogGroupNamePatterns = run.setup.id`, so a leaked test stack only claims log groups it owns.

## Background

The eng AWS account has many concurrently deployed logwriter stacks (real ones plus a number of leftover test stacks from aborted integration runs). Each stack's subscriber Lambda runs on a `DiscoveryRate` schedule and converges its log groups to "the filter I think I own". The "is this filter mine" check in `pkg/handler/subscriber/subscription.go` is name-prefix-based:

```go
case !strings.HasPrefix(aws.ToString(f.FilterName), aws.ToString(h.subscriptionFilter.FilterName)):
    // subscription filter not managed by this handler
    continue
```

With every stack defaulting to `FilterName = "observe-logs-subscription"`, every subscriber matches every other subscriber's filter, sees a "different" destination, deletes it, and replaces with its own. The result is constant `PutSubscriptionFilter` churn (~12k calls in 7.5 hours observed for one log group) and intermittent multi-hour gaps in log delivery for any log group in scope of multiple stacks.

CloudTrail showed at least 20 distinct `*-SubscriberRole` principals fighting over the same filter name on a single log group, with destinations cycling through Firehoses owned by each stack.

This PR makes the default `FilterName` stack-unique, so the existing prefix-match ownership check correctly only manages each stack's own filter. AWS still caps subscription filters at 2 per log group, so up to 2 logwriter stacks can coexist on any given log group; beyond that, additional subscribers will see the limit and skip without overwriting (existing behavior in `SubscriptionFilterDiff`).

The integration-test scoping change is a defense-in-depth fix: even with unique filter names, having every test stack enumerate every log group in the account is wasteful and contributes to noise. Scoping each test to its own random pet name keeps it operating only on log groups it created.

## Test plan

- [x] `make sam-validate-logwriter` (valid)
- [x] `make sam-validate-stack` (valid)
- [x] `go test ./pkg/handler/subscriber/...` (existing tests use `observe-logs-subscription` as fixture data and continue to pass)
- [x] Run the integration test suite end-to-end (`make test-integration-logwriter`, `make test-integration-stack`, etc.) to confirm scoped patterns still satisfy `check_subscriber`

## Follow-ups (separate PRs)

- Delete the ~18 leaked adjective-animal stacks in eng (`noted-lamprey`, `working-marten`, ..., all dating to 2025-12-10). Verified that none have a corresponding active filedrop in the Observe meta API, so their data is dead-ended.
- Add a CI/cron safety net to garbage-collect test stacks older than N hours, to prevent future leaks.
- Optional defense-in-depth: tighten `SubscriptionFilterDiff` to check destination ARN as well as name prefix when claiming ownership (matching the existing `cleanup.go` pattern at lines 146-152).

🤖 Generated with [Claude Code](https://claude.com/claude-code)