### PR TITLE
feat(metricsconfigurator): tag-based metric stream cleanup on stack delete

### DIFF
--- a/apps/metricstream/template.yaml
+++ b/apps/metricstream/template.yaml
@@ -247,8 +247,14 @@ Resources:
                 Action:
                   - cloudwatch:PutMetricStream
                   - cloudwatch:DeleteMetricStream
+                  - cloudwatch:TagResource
+                  - cloudwatch:ListTagsForResource
                 Resource: !Sub |-
                   arn:aws:cloudwatch:${AWS::Region}:${AWS::AccountId}:*
+              - Effect: Allow
+                Action:
+                  - cloudwatch:ListMetricStreams
+                Resource: '*'
               - Effect: Allow
                 Action:
                   - iam:PassRole
@@ -287,6 +293,7 @@ Resources:
       CodeUri: ../../bin/linux_arm64
       Handler: bootstrap
       Runtime: provided.al2023
+      Timeout: 60
       Architectures:
         - arm64
       LoggingConfig:

--- a/pkg/handler/metricsconfigurator/handler.go
+++ b/pkg/handler/metricsconfigurator/handler.go
@@ -32,6 +32,15 @@ func stackIdTags(stackId string) []types.Tag {
 	}
 }
 
+// cwAPI is the subset of cloudwatch.Client this handler uses. Defined as
+// an interface so tests can swap in a fake without touching real AWS.
+type cwAPI interface {
+	PutMetricStream(ctx context.Context, input *cloudwatch.PutMetricStreamInput, optFns ...func(*cloudwatch.Options)) (*cloudwatch.PutMetricStreamOutput, error)
+	ListMetricStreams(ctx context.Context, input *cloudwatch.ListMetricStreamsInput, optFns ...func(*cloudwatch.Options)) (*cloudwatch.ListMetricStreamsOutput, error)
+	ListTagsForResource(ctx context.Context, input *cloudwatch.ListTagsForResourceInput, optFns ...func(*cloudwatch.Options)) (*cloudwatch.ListTagsForResourceOutput, error)
+	DeleteMetricStream(ctx context.Context, input *cloudwatch.DeleteMetricStreamInput, optFns ...func(*cloudwatch.Options)) (*cloudwatch.DeleteMetricStreamOutput, error)
+}
+
 type GraphQLRequest struct {
 	Query string `json:"query"`
 }
@@ -47,6 +56,17 @@ type Handler struct {
 	ObserveDomainName string
 	SecretName        string
 	FilterUri         string
+
+	// NewCloudWatchClient overrides the default cloudwatch.NewFromConfig
+	// constructor. nil in production; tests inject a fake.
+	NewCloudWatchClient func(aws.Config) cwAPI
+}
+
+func (h Handler) cwClient(cfg aws.Config) cwAPI {
+	if h.NewCloudWatchClient != nil {
+		return h.NewCloudWatchClient(cfg)
+	}
+	return cloudwatch.NewFromConfig(cfg)
 }
 
 type Config struct {
@@ -165,7 +185,7 @@ func (h Handler) invokeDatasourcePath(ctx context.Context, cfg aws.Config, req *
 	}
 	logger.V(4).Info("parsed response, metric filters", "filters", metricsFilters)
 
-	cwClient := cloudwatch.NewFromConfig(cfg)
+	cwClient := h.cwClient(cfg)
 
 	filterGroups := h.makeMetricGroups(metricsFilters)
 	for idx, filterGroup := range filterGroups {
@@ -206,7 +226,7 @@ func (h Handler) invokeFilterUriPath(ctx context.Context, cfg aws.Config, req *R
 		return h.reportAndError("failed to parse filter YAML", req, err)
 	}
 
-	cwClient := cloudwatch.NewFromConfig(cfg)
+	cwClient := h.cwClient(cfg)
 	name := fmt.Sprintf("%s-%s-%d", h.MetricStreamName, "metric-stream", 0)
 
 	input := &cloudwatch.PutMetricStreamInput{
@@ -267,7 +287,7 @@ func (h Handler) handleDelete(ctx context.Context, cfg aws.Config, req *Request)
 	logger := h.Logger
 	logger.V(3).Info("delete request received, finding metric streams tagged for this stack", "stackId", req.StackId)
 
-	cwClient := cloudwatch.NewFromConfig(cfg)
+	cwClient := h.cwClient(cfg)
 
 	var matchingNames []string
 	var nextToken *string

--- a/pkg/handler/metricsconfigurator/handler.go
+++ b/pkg/handler/metricsconfigurator/handler.go
@@ -21,6 +21,17 @@ import (
 const bearerTokenFormat = "Bearer %s %s"
 const maxNumMetricNames = 1000
 
+// stackIdTagKey identifies metric streams created by this Lambda for a
+// particular CloudFormation stack. It is set on every PutMetricStream and
+// is the basis for ownership-checked cleanup in handleDelete.
+const stackIdTagKey = "aws-sam-apps:stack-id"
+
+func stackIdTags(stackId string) []types.Tag {
+	return []types.Tag{
+		{Key: aws.String(stackIdTagKey), Value: aws.String(stackId)},
+	}
+}
+
 type GraphQLRequest struct {
 	Query string `json:"query"`
 }
@@ -165,6 +176,7 @@ func (h Handler) invokeDatasourcePath(ctx context.Context, cfg aws.Config, req *
 			OutputFormat:   types.MetricStreamOutputFormat(h.OutputFormat),
 			Name:           &name,
 			IncludeFilters: filterGroup,
+			Tags:           stackIdTags(req.StackId),
 		})
 		if err != nil {
 			return h.reportAndError("failed to add filter to metric stream", req, err)
@@ -202,6 +214,7 @@ func (h Handler) invokeFilterUriPath(ctx context.Context, cfg aws.Config, req *R
 		RoleArn:      &h.RoleArn,
 		OutputFormat: types.MetricStreamOutputFormat(h.OutputFormat),
 		Name:         &name,
+		Tags:         stackIdTags(req.StackId),
 	}
 
 	// Include and exclude are handled asymmetrically: we assume customers can
@@ -222,6 +235,7 @@ func (h Handler) invokeFilterUriPath(ctx context.Context, cfg aws.Config, req *R
 				OutputFormat:   types.MetricStreamOutputFormat(h.OutputFormat),
 				Name:           &streamName,
 				IncludeFilters: filterGroup,
+				Tags:           stackIdTags(req.StackId),
 			})
 			if err != nil {
 				return h.reportAndError("failed to put metric stream with include filters", req, err)
@@ -243,18 +257,70 @@ func (h Handler) invokeFilterUriPath(ctx context.Context, cfg aws.Config, req *R
 	return nil
 }
 
-// handleDelete is a no-op for stream cleanup. DeleteMetricStream silently
-// succeeds on nonexistent names, and prefix-match by MetricStreamName has
-// no way to prove a stream was created by this stack vs. another stack
-// with the same NameOverride or a customer's hand-rolled stream.
-// Safe ownership-checked cleanup (tag-on-put + GetResources by tag) lands
-// as a fast-follow; until then streams are orphaned on stack delete (their
-// Firehose target is destroyed by CFN, so the orphans deliver nothing and
-// must be manually deleted by the operator).
-func (h Handler) handleDelete(_ context.Context, _ aws.Config, req *Request) ([]byte, error) {
+// handleDelete cleans up metric streams created by this Lambda for this
+// stack. It pages through all metric streams in the account and deletes
+// the ones tagged with our stack-id (set on every PutMetricStream).
+// Streams without our tag — including streams from other stacks that
+// happen to share a name prefix, customer-managed streams, or pre-PR
+// orphans created before tagging was introduced — are not touched.
+func (h Handler) handleDelete(ctx context.Context, cfg aws.Config, req *Request) ([]byte, error) {
 	logger := h.Logger
-	logger.V(3).Info("delete request received; metric stream cleanup deferred to operator (see fast-follow)")
-	if reportErr := h.reportStatus(*req, true, "delete acknowledged; metric stream cleanup not performed"); reportErr != nil {
+	logger.V(3).Info("delete request received, finding metric streams tagged for this stack", "stackId", req.StackId)
+
+	cwClient := cloudwatch.NewFromConfig(cfg)
+
+	var matchingNames []string
+	var nextToken *string
+	for {
+		page, err := cwClient.ListMetricStreams(ctx, &cloudwatch.ListMetricStreamsInput{
+			NextToken: nextToken,
+		})
+		if err != nil {
+			return nil, h.reportAndError("failed to list metric streams", req, err)
+		}
+		for _, entry := range page.Entries {
+			if entry.Arn == nil || entry.Name == nil {
+				continue
+			}
+			tagsOut, err := cwClient.ListTagsForResource(ctx, &cloudwatch.ListTagsForResourceInput{
+				ResourceARN: entry.Arn,
+			})
+			if err != nil {
+				logger.Error(err, "failed to list tags for stream, skipping", "name", *entry.Name)
+				continue
+			}
+			for _, tag := range tagsOut.Tags {
+				if tag.Key != nil && *tag.Key == stackIdTagKey &&
+					tag.Value != nil && *tag.Value == req.StackId {
+					matchingNames = append(matchingNames, *entry.Name)
+					break
+				}
+			}
+		}
+		if page.NextToken == nil {
+			break
+		}
+		nextToken = page.NextToken
+	}
+
+	logger.V(3).Info("found metric streams to delete", "count", len(matchingNames))
+
+	var deleted int
+	for i := range matchingNames {
+		name := matchingNames[i]
+		_, err := cwClient.DeleteMetricStream(ctx, &cloudwatch.DeleteMetricStreamInput{
+			Name: &name,
+		})
+		if err != nil {
+			logger.Error(err, "failed to delete metric stream, continuing", "name", name)
+			continue
+		}
+		deleted++
+		logger.V(3).Info("deleted metric stream", "name", name)
+	}
+
+	reason := fmt.Sprintf("deleted %d of %d metric stream(s) tagged for this stack", deleted, len(matchingNames))
+	if reportErr := h.reportStatus(*req, true, reason); reportErr != nil {
 		return nil, fmt.Errorf("failed to report status to cloudformation: %w", reportErr)
 	}
 	return []byte{}, nil

--- a/pkg/handler/metricsconfigurator/handler_delete_test.go
+++ b/pkg/handler/metricsconfigurator/handler_delete_test.go
@@ -1,0 +1,175 @@
+package metricsconfigurator
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatch"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
+	"github.com/go-logr/logr"
+
+	"github.com/observeinc/aws-sam-apps/pkg/testing/awstest"
+)
+
+const testHandleDeleteStackId = "arn:aws:cloudformation:us-west-2:000000000000:stack/MyStack/abc123"
+
+// stream is a small constructor for awstest.MetricStreamRecord that
+// keeps the test bodies readable.
+func stream(name string, stackIdTagValue string) awstest.MetricStreamRecord {
+	rec := awstest.MetricStreamRecord{
+		Name: name,
+		Arn:  "arn:aws:cloudwatch:us-west-2:000000000000:metric-stream/" + name,
+	}
+	if stackIdTagValue != "" {
+		rec.Tags = []types.Tag{{Key: aws.String(stackIdTagKey), Value: aws.String(stackIdTagValue)}}
+	}
+	return rec
+}
+
+// streamWithTags lets a test pin arbitrary tags on a stream record
+// (e.g. tags other than ours).
+func streamWithTags(name string, tags []types.Tag) awstest.MetricStreamRecord {
+	return awstest.MetricStreamRecord{
+		Name: name,
+		Arn:  "arn:aws:cloudwatch:us-west-2:000000000000:metric-stream/" + name,
+		Tags: tags,
+	}
+}
+
+// newDeleteHandler returns a Handler wired to the given fake CloudWatch
+// client. The CFN response URL points at a discarding test server so
+// reportStatus calls succeed.
+func newDeleteHandler(t *testing.T, cw *awstest.CloudWatchClient) (Handler, *httptest.Server) {
+	t.Helper()
+	cfn := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(cfn.Close)
+	h := Handler{
+		Logger:              logr.Discard(),
+		NewCloudWatchClient: func(aws.Config) cwAPI { return cw },
+	}
+	return h, cfn
+}
+
+func deleteRequest(cfnURL string) *Request {
+	return &Request{
+		RequestType:       "Delete",
+		ResponseURL:       cfnURL,
+		StackId:           testHandleDeleteStackId,
+		RequestId:         "req-1",
+		LogicalResourceId: "MetricStream",
+	}
+}
+
+// streamNames returns the names of streams currently in the fake, in order.
+func streamNames(cw *awstest.CloudWatchClient) []string {
+	names := make([]string, len(cw.Streams))
+	for i, s := range cw.Streams {
+		names[i] = s.Name
+	}
+	return names
+}
+
+func TestHandleDelete_OnlyDeletesOwnStreams(t *testing.T) {
+	// Mix four streams in the account:
+	//   - one tagged with our stack id (must be deleted)
+	//   - one tagged with a different stack id (must be left alone)
+	//   - one tagged but with a non-stack-id key (must be left alone)
+	//   - one with no tags at all (must be left alone)
+	cw := &awstest.CloudWatchClient{
+		Streams: []awstest.MetricStreamRecord{
+			stream("ours", testHandleDeleteStackId),
+			stream("other-stack", "arn:aws:cloudformation:us-west-2:000000000000:stack/OtherStack/zzz"),
+			streamWithTags("customer-managed", []types.Tag{
+				{Key: aws.String("Owner"), Value: aws.String("customer")},
+			}),
+			streamWithTags("untagged", nil),
+		},
+	}
+	h, cfn := newDeleteHandler(t, cw)
+
+	if _, err := h.handleDelete(context.Background(), aws.Config{}, deleteRequest(cfn.URL)); err != nil {
+		t.Fatalf("handleDelete returned error: %v", err)
+	}
+
+	got := streamNames(cw)
+	want := []string{"other-stack", "customer-managed", "untagged"}
+	if !equalSlices(got, want) {
+		t.Errorf("surviving streams = %v, want %v", got, want)
+	}
+}
+
+func TestHandleDelete_Pagination(t *testing.T) {
+	// Five streams all owned by us, returned across multiple pages.
+	streams := make([]awstest.MetricStreamRecord, 5)
+	for i := range streams {
+		streams[i] = stream(streamNameFromIdx(i), testHandleDeleteStackId)
+	}
+	cw := &awstest.CloudWatchClient{Streams: streams, PageSize: 2}
+	h, cfn := newDeleteHandler(t, cw)
+
+	if _, err := h.handleDelete(context.Background(), aws.Config{}, deleteRequest(cfn.URL)); err != nil {
+		t.Fatalf("handleDelete returned error: %v", err)
+	}
+
+	if got := streamNames(cw); len(got) != 0 {
+		t.Errorf("expected all streams deleted, still have: %v", got)
+	}
+}
+
+func TestHandleDelete_ListTagsErrorIsTolerated(t *testing.T) {
+	// Three streams, all owned by us. ListTagsForResource fails on the
+	// middle stream; the surrounding streams must still be deleted, the
+	// failing one must be left alone (we can't prove ownership).
+	cw := &awstest.CloudWatchClient{
+		Streams: []awstest.MetricStreamRecord{
+			stream("first", testHandleDeleteStackId),
+			stream("middle", testHandleDeleteStackId),
+			stream("last", testHandleDeleteStackId),
+		},
+	}
+	cw.ListTagsForResourceFunc = func(_ context.Context, in *cloudwatch.ListTagsForResourceInput, _ ...func(*cloudwatch.Options)) (*cloudwatch.ListTagsForResourceOutput, error) {
+		if aws.ToString(in.ResourceARN) == "arn:aws:cloudwatch:us-west-2:000000000000:metric-stream/middle" {
+			return nil, errors.New("transient list-tags failure")
+		}
+		// Fall back to seeded tags for the other streams.
+		for _, s := range cw.Streams {
+			if s.Arn == aws.ToString(in.ResourceARN) {
+				return &cloudwatch.ListTagsForResourceOutput{Tags: append([]types.Tag(nil), s.Tags...)}, nil
+			}
+		}
+		return &cloudwatch.ListTagsForResourceOutput{}, nil
+	}
+	h, cfn := newDeleteHandler(t, cw)
+
+	if _, err := h.handleDelete(context.Background(), aws.Config{}, deleteRequest(cfn.URL)); err != nil {
+		t.Fatalf("handleDelete returned error: %v", err)
+	}
+
+	got := streamNames(cw)
+	want := []string{"middle"}
+	if !equalSlices(got, want) {
+		t.Errorf("surviving streams = %v, want %v (only the list-tags-failed stream should remain)", got, want)
+	}
+}
+
+func streamNameFromIdx(i int) string {
+	return string(rune('a' + i))
+}
+
+func equalSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/testing/awstest/cloudwatch.go
+++ b/pkg/testing/awstest/cloudwatch.go
@@ -1,0 +1,129 @@
+package awstest
+
+import (
+	"context"
+	"errors"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatch"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
+)
+
+// MetricStreamRecord is a fake metric stream entry used by CloudWatchClient.
+// Tags are stored on the record so tests can verify tag-based selection
+// without a separate tag store.
+type MetricStreamRecord struct {
+	Name string
+	Arn  string
+	Tags []types.Tag
+}
+
+// CloudWatchClient is a fake cloudwatch.Client suitable for unit tests.
+// It implements the subset of the SDK surface that pkg/handler/metricsconfigurator
+// uses: PutMetricStream, ListMetricStreams (with pagination), ListTagsForResource,
+// and DeleteMetricStream.
+//
+// Streams holds the in-memory state of metric streams. PutMetricStream
+// appends or replaces by Name. DeleteMetricStream removes by Name.
+//
+// PageSize controls the number of entries ListMetricStreams returns per
+// page (0 means "all in one page").
+//
+// Each method has an optional Func override for tests that need to inject
+// errors or custom behavior.
+type CloudWatchClient struct {
+	Streams  []MetricStreamRecord
+	PageSize int
+
+	PutMetricStreamFunc     func(context.Context, *cloudwatch.PutMetricStreamInput, ...func(*cloudwatch.Options)) (*cloudwatch.PutMetricStreamOutput, error)
+	ListMetricStreamsFunc   func(context.Context, *cloudwatch.ListMetricStreamsInput, ...func(*cloudwatch.Options)) (*cloudwatch.ListMetricStreamsOutput, error)
+	ListTagsForResourceFunc func(context.Context, *cloudwatch.ListTagsForResourceInput, ...func(*cloudwatch.Options)) (*cloudwatch.ListTagsForResourceOutput, error)
+	DeleteMetricStreamFunc  func(context.Context, *cloudwatch.DeleteMetricStreamInput, ...func(*cloudwatch.Options)) (*cloudwatch.DeleteMetricStreamOutput, error)
+}
+
+func (c *CloudWatchClient) PutMetricStream(ctx context.Context, input *cloudwatch.PutMetricStreamInput, opts ...func(*cloudwatch.Options)) (*cloudwatch.PutMetricStreamOutput, error) {
+	if c.PutMetricStreamFunc != nil {
+		return c.PutMetricStreamFunc(ctx, input, opts...)
+	}
+	if input.Name == nil {
+		return nil, errors.New("PutMetricStream: Name is required")
+	}
+	rec := MetricStreamRecord{
+		Name: aws.ToString(input.Name),
+		Arn:  "arn:aws:cloudwatch:us-west-2:000000000000:metric-stream/" + aws.ToString(input.Name),
+		Tags: input.Tags,
+	}
+	for i, s := range c.Streams {
+		if s.Name == rec.Name {
+			c.Streams[i] = rec
+			return &cloudwatch.PutMetricStreamOutput{Arn: aws.String(rec.Arn)}, nil
+		}
+	}
+	c.Streams = append(c.Streams, rec)
+	return &cloudwatch.PutMetricStreamOutput{Arn: aws.String(rec.Arn)}, nil
+}
+
+func (c *CloudWatchClient) ListMetricStreams(ctx context.Context, input *cloudwatch.ListMetricStreamsInput, opts ...func(*cloudwatch.Options)) (*cloudwatch.ListMetricStreamsOutput, error) {
+	if c.ListMetricStreamsFunc != nil {
+		return c.ListMetricStreamsFunc(ctx, input, opts...)
+	}
+
+	start := 0
+	if input.NextToken != nil {
+		// Tokens we hand out are zero-based start indexes encoded as strings.
+		for i, s := range c.Streams {
+			if s.Name == aws.ToString(input.NextToken) {
+				start = i
+				break
+			}
+		}
+	}
+
+	end := len(c.Streams)
+	if c.PageSize > 0 && start+c.PageSize < end {
+		end = start + c.PageSize
+	}
+
+	entries := make([]types.MetricStreamEntry, 0, end-start)
+	for _, s := range c.Streams[start:end] {
+		name := s.Name
+		arn := s.Arn
+		entries = append(entries, types.MetricStreamEntry{Name: &name, Arn: &arn})
+	}
+
+	var next *string
+	if end < len(c.Streams) {
+		// Use the next stream's name as the page token.
+		token := c.Streams[end].Name
+		next = &token
+	}
+	return &cloudwatch.ListMetricStreamsOutput{Entries: entries, NextToken: next}, nil
+}
+
+func (c *CloudWatchClient) ListTagsForResource(ctx context.Context, input *cloudwatch.ListTagsForResourceInput, opts ...func(*cloudwatch.Options)) (*cloudwatch.ListTagsForResourceOutput, error) {
+	if c.ListTagsForResourceFunc != nil {
+		return c.ListTagsForResourceFunc(ctx, input, opts...)
+	}
+	for _, s := range c.Streams {
+		if s.Arn == aws.ToString(input.ResourceARN) {
+			tags := make([]types.Tag, len(s.Tags))
+			copy(tags, s.Tags)
+			return &cloudwatch.ListTagsForResourceOutput{Tags: tags}, nil
+		}
+	}
+	return &cloudwatch.ListTagsForResourceOutput{}, nil
+}
+
+func (c *CloudWatchClient) DeleteMetricStream(ctx context.Context, input *cloudwatch.DeleteMetricStreamInput, opts ...func(*cloudwatch.Options)) (*cloudwatch.DeleteMetricStreamOutput, error) {
+	if c.DeleteMetricStreamFunc != nil {
+		return c.DeleteMetricStreamFunc(ctx, input, opts...)
+	}
+	target := aws.ToString(input.Name)
+	for i, s := range c.Streams {
+		if s.Name == target {
+			c.Streams = append(c.Streams[:i], c.Streams[i+1:]...)
+			return &cloudwatch.DeleteMetricStreamOutput{}, nil
+		}
+	}
+	return &cloudwatch.DeleteMetricStreamOutput{}, nil
+}


### PR DESCRIPTION
## Summary

Fast-follow to #462. PR 1 left \`handleDelete\` as a no-op; this PR makes stack delete actually clean up the metric streams it created, with ownership semantics that don't risk deleting other stacks' or customer-owned streams.

- On every \`PutMetricStream\` (both \`invokeFilterUriPath\` and \`invokeDatasourcePath\`), pass \`Tags=[{aws-sam-apps:stack-id: req.StackId}]\`. \`req.StackId\` is already in the custom-resource payload — no extra state to persist.
- \`handleDelete\` now pages through \`cloudwatch:ListMetricStreams\` for the account, calls \`ListTagsForResource\` on each, and \`DeleteMetricStream\` only on streams whose \`aws-sam-apps:stack-id\` tag matches the current stack's id.
- IAM additions on the Lambda role: \`cloudwatch:TagResource\` (required when \`PutMetricStream\` is called with \`Tags\`), \`cloudwatch:ListTagsForResource\`, and \`cloudwatch:ListMetricStreams\` (account-wide; no per-resource ARN).
- Lambda \`Timeout\` bumped from SAM's 3-second default to 60s — \`ListMetricStreams\` + N×\`ListTagsForResource\` is comfortably slower than that with the old 3s ceiling.

## Why this exists

Discovered while doing the CRUD walk-through on #462: the original cleanup loop walked stream names by index calling \`DeleteMetricStream\`, but \`DeleteMetricStream\` silently succeeds on nonexistent names, so the loop ran until Lambda timeout. Worse, a prefix-match by \`MetricStreamName\` would happily delete streams owned by *another* stack reusing the same \`NameOverride\`, customer-managed streams that happen to match the prefix, or streams from a previous deploy in the same account+region.

We deliberately scoped the fix to a separate PR so #462 could land first with the cleanup deferred (no-op + a documented \"orphan on delete\" caveat).

## Side benefit

The pre-existing **datasource** path has had the orphan-on-delete bug since it was first added — its original \`Delete\` handler just returned SUCCESS without calling \`DeleteMetricStream\`. Tagging on \`PutMetricStream\` + tag-filter cleanup covers both paths uniformly, so this also retroactively fixes that.

## Customer-visible impact

- On stack delete, the metric stream(s) the Lambda created are removed automatically. No more orphans (no manual \`aws cloudwatch delete-metric-stream\` cleanup, no surprise CloudWatch metric-stream charges after delete).
- New IAM grants on the Lambda role's policy: \`cloudwatch:TagResource\`, \`cloudwatch:ListTagsForResource\`, \`cloudwatch:ListMetricStreams\`.
- Streams created by previous versions of this stack (before this PR landed) **will not** be cleaned up on delete — they don't have the tag, and we will not touch streams whose ownership we can't prove. Operators upgrading from #462 should manually clean up any leftover streams from prior deploys.

## Test plan

- [x] \`make go-test\` passes.
- [x] \`make go-lint\` passes (0 issues).
- [x] \`make sam-validate\` passes.
- [ ] Manual CRUD walk-through against blunderdome / us-west-2 (planned, similar to #462).
- [ ] CI: integration test \`metricstream\`.
- [ ] CI: integration test \`stack\`.

## Stacking

This PR targets \`feat/metricsconfigurator-filteruri\` (#462). Once #462 merges to main, GitHub will retarget this PR to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)