### PR TITLE
feat: add StackSet wrappers for org-wide deployment

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -35,17 +35,18 @@ and the most important variables, run `make help`, e.g:
 
 ```
 VARIABLES:
-  APPS          = config configsubscription firehose forwarder logwriter metricstream stack
+  APPS          = config configsubscription externalrole externalrole-stackset forwarder logwriter logwriter-stackset metricstream metricstream-stackset stack
   AWS_REGION    = us-west-2
-  GO_BINS       = forwarder subscriber metricsconfigurator
+  GO_BINS       = forwarder subscriber metricsconfigurator pollerconfigurator
   GO_BUILD_DIRS = bin/linux_arm64 .go/bin/linux_arm64 .go/cache .go/pkg
-  TF_TESTS      = config configsubscription firehose forwarder forwarder_s3 logwriter metricstream simple stack
+  TF_TESTS      = config configsubscription externalrole forwarder forwarder_s3 logwriter metricstream simple stack stack_including_metricspollerrole
   VERSION       = v1.19.2-4-gb1238b5-dirty
 
 TARGETS:
   clean                           removes built binaries and temporary files.
   go-build                        build Go binaries.
   go-clean                        clean Go temp files.
+  lambda-zips                     build Lambda ZIP archives for non-SAM-managed functions.
   ...
 ```
 
@@ -57,14 +58,26 @@ TARGETS:
 
 # package a single SAM app, will upload lambda function to S3
 → make sam-package-forwarder
+→ make sam-package-logwriter
 ```
 
 At this point, you will have a functional CloudFormation template under
-`.aws-sam/build/regions/${AWS_REGION}/forwarder.yaml`. You can deploy this by:
+`.aws-sam/build/regions/${AWS_REGION}/${APP}.yaml`. You can deploy this by:
 
 - uploading manually using Cloudformation console
 - deploying through `sam deploy`
 - installing via Terraform
+
+For apps with Lambda functions that SAM doesn't manage natively (logwriter,
+metricstream, externalrole, stack), the packaging step automatically builds
+Lambda ZIPs, uploads them to S3, and embeds the S3 references as parameter
+defaults in the packaged template. An S3 bucket is auto-created using the
+naming convention `aws-sam-apps-${ACCOUNT_ID}-${REGION}`. You can override
+this by setting `S3_BUCKET_PREFIX`:
+
+```
+S3_BUCKET_PREFIX=my-bucket- make sam-package-logwriter
+```
 
 ## Running tests
 
@@ -133,13 +146,37 @@ Go build directory, to the temporary build directory provided through the
 `build-${ResourceName}`. By convention our resource name for a Lambda function
 in the CloudFormation template is always the capitalied binary name.
 
+### Lambda ZIPs
+
+Some apps (logwriter, metricstream, externalrole) use plain
+`AWS::Lambda::Function` resources instead of `AWS::Serverless::Function`
+because CloudFormation StackSets do not support the SAM transform.
+SAM's `package` command does not handle code uploads for these. The Makefile
+builds bootstrap-style ZIPs for each Lambda binary listed in `LAMBDA_ZIP_BINS`
+and uploads them to S3 during `make sam-package`. The ZIPs are stored in
+`.aws-sam/build/lambda-zips/`.
+
+To build only the ZIPs (without packaging): `make lambda-zips`
+
 ### SAM package
 
 `make sam-package` takes the artifact directory created by `sam build`, and
-pushes the assets to S3. If no `S3_BUCKET_PREFIX` is provied, `samcli` will
-create an S3 bucket for you. It will render a new CloudFormation template which
+pushes the assets to S3. If no `S3_BUCKET_PREFIX` is provided, a default
+bucket is auto-created as `aws-sam-apps-${ACCOUNT_ID}-${REGION}` using your
+current AWS credentials. It will render a new CloudFormation template which
 references the resulting S3 URIs. This template is stored in
 `.aws-sam/build/regions/${AWS_REGION}/${APP}.yaml`
+
+For apps with non-SAM-managed Lambdas, the packaging step also uploads the
+Lambda ZIPs to S3 and post-processes the output template to embed the S3
+bucket and key as parameter defaults, making the template self-contained.
+The packaged template is then uploaded to S3. This is necessary because
+StackSet resources require a `TemplateURL` pointing to S3 -- CloudFormation
+must distribute the template to spoke accounts across the organization and
+cannot reference a local file path. This upload means `sam-push` is not
+needed for local StackSet testing. If a corresponding stackset template
+exists (e.g. `apps/logwriter-stackset/`), it is also copied into the build
+output directory and uploaded to S3.
 
 Lambda functions can only reference binaries stored in the same region. For
 this reason, the result of running `sam package` is always region specific.
@@ -306,21 +343,148 @@ during setup and teardown as well
 Upon each release, the SAM applications and their associated artifacts are packaged and uploaded to our S3 buckets. The naming convention and directory structure for these buckets are as follows:
 
 ```
-observeinc-$REGION/apps/$APP/$VERSION/packaged.yaml
-observeinc-$REGION/apps/$APP/latest/packaged.yaml
-observeinc-$REGION/apps/$APP/beta/packaged.yaml
+observeinc-$REGION/aws-sam-apps/$VERSION/
+  forwarder.yaml
+  logwriter.yaml
+  metricstream.yaml
+  externalrole.yaml
+  stack.yaml
+  logwriter-stackset.yaml
+  metricstream-stackset.yaml
+  externalrole-stackset.yaml
+  subscriber.zip
+  metricsconfigurator.zip
+  pollerconfigurator.zip
+  <hash>                          (forwarder code, uploaded by SAM natively)
 ```
 
-For instance:
+Templates for apps with Lambdas (logwriter, metricstream, externalrole, stack)
+have their `LambdaS3BucketPrefix` and `LambdaS3Key*` parameter defaults
+pre-populated with the S3 bucket and key where the Lambda ZIPs were uploaded.
 
-For the collection app, version 1.0.1 being deployed to the us-west-1 region, the artifact would be located at:
-observeinc-us-west-1/apps/collection/1.0.1/packaged.yaml
+The `latest` and `beta` tags are maintained as copies of the corresponding
+versioned directory.
 
-For the latest version of the same app in the same region:
-observeinc-us-west-1/apps/collection/latest/packaged.yaml
+## StackSet Templates
 
-For the beta version of the same app in the same region:
-observeinc-us-west-1/apps/collection/beta/packaged.yaml
+The `apps/` directory contains `-stackset` variants for deploying across an
+AWS Organization via CloudFormation StackSets:
+
+- `logwriter-stackset` -- deploys LogWriter across member accounts
+- `metricstream-stackset` -- deploys MetricStream across member accounts
+- `externalrole-stackset` -- deploys the external IAM role and PollerConfigurator
+
+Each stackset template is a thin wrapper around `AWS::CloudFormation::StackSet`
+that references the underlying app template via a `TemplateURL` parameter. The
+underlying templates (logwriter, metricstream, externalrole) use plain
+`AWS::Lambda::Function` (not `AWS::Serverless::Function`) because StackSets
+do not support the SAM transform.
+
+### Testing StackSets locally
+
+The local StackSet dev workflow has three steps: package, deploy, and iterate.
+
+#### 1. Package the app
+
+`make sam-package-<app>` builds, packages, and uploads everything to S3 in one
+command:
+
+```sh
+make sam-package-logwriter
+```
+
+This produces:
+- `.aws-sam/build/regions/us-west-2/logwriter.yaml` -- packaged template with
+  embedded Lambda S3 defaults
+- `.aws-sam/build/regions/us-west-2/logwriter-stackset.yaml` -- stackset
+  wrapper template (copied from `apps/logwriter-stackset/template.yaml`)
+- Both templates and Lambda ZIPs are uploaded to the auto-created S3 bucket
+
+#### 2. Deploy the stackset
+
+Use `aws cloudformation create-stack` with the local stackset wrapper template.
+The `TemplateURL` parameter points to the packaged template in S3:
+
+```sh
+BUCKET=aws-sam-apps-$(aws sts get-caller-identity --query Account --output text)-us-west-2
+VERSION=$(git describe --tags --always --dirty)
+
+aws cloudformation create-stack \
+  --stack-name obs-logwriter-stackset \
+  --template-body file://.aws-sam/build/regions/us-west-2/logwriter-stackset.yaml \
+  --parameters \
+    ParameterKey=TemplateURL,ParameterValue=https://${BUCKET}.s3.us-west-2.amazonaws.com/aws-sam-apps/${VERSION}/logwriter.yaml \
+    ParameterKey=TargetOUs,ParameterValue=ou-XXXX-XXXXXXXX \
+    ParameterKey=TargetRegions,ParameterValue=us-west-2 \
+    ParameterKey=BucketArn,ParameterValue=arn:aws:s3:::YOUR-COLLECTION-BUCKET \
+    ParameterKey=NameOverride,ParameterValue=obs-logwriter \
+  --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND \
+  --region us-west-2
+```
+
+The stackset wrapper can be deployed from a local file because only the
+management account reads it. The underlying template (`TemplateURL`) must be
+in S3 because CloudFormation distributes it to spoke accounts.
+
+#### 3. Iterate
+
+After making changes to the underlying app template, re-run `make sam-package`
+and update the stack:
+
+```sh
+make sam-package-logwriter
+
+aws cloudformation update-stack \
+  --stack-name obs-logwriter-stackset \
+  --template-body file://.aws-sam/build/regions/us-west-2/logwriter-stackset.yaml \
+  --parameters \
+    ParameterKey=TemplateURL,ParameterValue=https://${BUCKET}.s3.us-west-2.amazonaws.com/aws-sam-apps/${VERSION}/logwriter.yaml \
+    ParameterKey=TargetOUs,UsePreviousValue=true \
+    ParameterKey=TargetRegions,UsePreviousValue=true \
+    ParameterKey=BucketArn,UsePreviousValue=true \
+    ParameterKey=NameOverride,UsePreviousValue=true \
+  --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND \
+  --region us-west-2
+```
+
+If only the stackset wrapper template changed (not the underlying app), you can
+update just the wrapper -- the `TemplateURL` stays the same.
+
+#### Notes
+
+- `NameOverride` is recommended to keep IAM role and resource names within the
+  64-character limit imposed by CloudFormation StackSet naming.
+- For `CommaDelimitedList` parameters (e.g. `AllowedActions`), pass commas
+  literally in the value. Do not backslash-escape them -- the backslashes end
+  up in the IAM policy.
+- Monitor StackSet operations with
+  `aws cloudformation list-stack-set-operations --stack-set-name <name>`.
+
+## Upgrading from SAM-based templates
+
+The logwriter, metricstream, and externalrole templates were converted from
+`AWS::Serverless::Function` to plain `AWS::Lambda::Function` to support
+StackSet deployments. When upgrading an existing stack to the new template
+version, be aware of the following expected behaviors:
+
+### MetricStream (filter URI path)
+
+Customers using the filter URI path (no `DatasourceID`) will experience a
+brief gap in CloudWatch Metrics collection during the stack update. The
+previous CloudFormation-managed `AWS::CloudWatch::MetricStream` resource is
+replaced by a Lambda-managed metric stream. CloudFormation deletes the old
+resource before the Lambda custom resource creates the new one. Metrics
+collection resumes automatically once the custom resource completes
+(typically under one minute).
+
+### LogWriter subscriber
+
+The SQS event source mapping for the Subscriber Lambda changes logical IDs
+during the upgrade (from SAM-generated to explicitly defined). CloudFormation
+deletes the old mapping and creates a new one, causing a brief window where
+SQS messages are not processed. No messages are lost -- the SQS queue retains
+messages for up to 14 days, and processing resumes as soon as the new mapping
+is active.
 
 ## Versioning and Contribution
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -418,7 +418,7 @@ aws cloudformation create-stack \
     ParameterKey=TargetRegions,ParameterValue=us-west-2 \
     ParameterKey=BucketArn,ParameterValue=arn:aws:s3:::YOUR-COLLECTION-BUCKET \
     ParameterKey=NameOverride,ParameterValue=obs-logwriter \
-  --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND \
+  --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM \
   --region us-west-2
 ```
 
@@ -443,7 +443,7 @@ aws cloudformation update-stack \
     ParameterKey=TargetRegions,UsePreviousValue=true \
     ParameterKey=BucketArn,UsePreviousValue=true \
     ParameterKey=NameOverride,UsePreviousValue=true \
-  --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND \
+  --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM \
   --region us-west-2
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -271,6 +271,11 @@ $(SAM_PACKAGE_TEMPLATES): | $(SAM_PACKAGE_DIRS)
 	  echo "# copying $${APP}-stackset.yaml -> $(dir $@)$${APP}-stackset.yaml" && \
 	  cp "apps/$${APP}-stackset/template.yaml" \
 	     "$(dir $@)$${APP}-stackset.yaml" && \
+	  export TEMPLATE_URL="https://$${BUCKET}.s3.$${REGION}.amazonaws.com/aws-sam-apps/$(VERSION)/$${APP}.yaml" && \
+	  echo "# embedding TemplateURL default: $${TEMPLATE_URL}" && \
+	  python3 scripts/embed-lambda-defaults.py \
+	    "$(dir $@)$${APP}-stackset.yaml" \
+	    "TemplateURL=$${TEMPLATE_URL}" && \
 	  echo "# uploading $${APP}-stackset.yaml -> s3://$${BUCKET}/aws-sam-apps/$(VERSION)/$${APP}-stackset.yaml" && \
 	  aws s3 cp "$(dir $@)$${APP}-stackset.yaml" \
 	    "s3://$${BUCKET}/aws-sam-apps/$(VERSION)/$${APP}-stackset.yaml" \
@@ -287,7 +292,7 @@ $(foreach target,$(SAM_PULL_REGION_TARGETS),$(eval  \
 $(SAM_PULL_REGION_TARGETS): require_bucket_prefix
 	# force ourselves to use the public URLs, verifying ACLs are correctly set
 	cd $(SAM_BUILD_DIR)/regions/$(subst sam-pull-,,$@) && \
-	for app in $(PACKAGEABLE_APPS); do \
+	for app in $(PACKAGEABLE_APPS) $(STACKSET_APPS); do \
 	  curl -fs \
 	    -O https://$(S3_BUCKET_PREFIX)$(subst sam-pull-,,$@).s3.$(subst sam-pull-,,$@).amazonaws.com/aws-sam-apps/$(VERSION)/$${app}.yaml \
 	    -w "Pulled %{url_effective} status=%{http_code} size=%{size_download}\n" || exit 1; \

--- a/Makefile
+++ b/Makefile
@@ -387,7 +387,11 @@ sam-push-%: # @HELP push all SAM apps to specific region (e.g sam-push-us-west-2
 
 .PHONY: sam-validate
 sam-validate: # @HELP validate all templates (SAM validate for SAM apps, cfn-lint for plain CloudFormation).
-sam-validate: $(SAM_VALIDATE_TARGETS) $(CFN_VALIDATE_TARGETS)
+sam-validate: $(SAM_VALIDATE_TARGETS) $(CFN_VALIDATE_TARGETS) check-stackset-param-parity
+
+.PHONY: check-stackset-param-parity
+check-stackset-param-parity: # @HELP check that StackSet wrappers mirror underlying app param constraints (AllowedPattern, AllowedValues, etc.)
+	python3 scripts/check-stackset-param-parity.py
 
 sam-validate-%: # @HELP validate specific SAM app (e.g. sam-validate-forwarder).
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,28 @@ This repository contains multiple SAM applications, each fulfilling a specific r
 | [![Static Badge](https://img.shields.io/badge/il_central_1-latest-blue?logo=amazonaws)](https://il-central-1.console.aws.amazon.com/cloudformation/home?region=il-central-1#/stacks/create/review?templateURL=https://observeinc-il-central-1.s3.amazonaws.com/aws-sam-apps/latest/stack.yaml) | [![Static Badge](https://img.shields.io/badge/il_central_1-latest-blue?logo=amazonaws)](https://il-central-1.console.aws.amazon.com/cloudformation/home?region=il-central-1#/stacks/create/review?templateURL=https://observeinc-il-central-1.s3.amazonaws.com/aws-sam-apps/latest/config.yaml) | [![Static Badge](https://img.shields.io/badge/il_central_1-latest-blue?logo=amazonaws)](https://il-central-1.console.aws.amazon.com/cloudformation/home?region=il-central-1#/stacks/create/review?templateURL=https://observeinc-il-central-1.s3.amazonaws.com/aws-sam-apps/latest/forwarder.yaml) |
 | [![Static Badge](https://img.shields.io/badge/mx_central_1-latest-blue?logo=amazonaws)](https://mx-central-1.console.aws.amazon.com/cloudformation/home?region=mx-central-1#/stacks/create/review?templateURL=https://observeinc-mx-central-1.s3.amazonaws.com/aws-sam-apps/latest/stack.yaml) | [![Static Badge](https://img.shields.io/badge/mx_central_1-latest-blue?logo=amazonaws)](https://mx-central-1.console.aws.amazon.com/cloudformation/home?region=mx-central-1#/stacks/create/review?templateURL=https://observeinc-mx-central-1.s3.amazonaws.com/aws-sam-apps/latest/config.yaml) | [![Static Badge](https://img.shields.io/badge/mx_central_1-latest-blue?logo=amazonaws)](https://mx-central-1.console.aws.amazon.com/cloudformation/home?region=mx-central-1#/stacks/create/review?templateURL=https://observeinc-mx-central-1.s3.amazonaws.com/aws-sam-apps/latest/forwarder.yaml) |
 
+## Deployment Modes
+
+This repository supports two deployment modes:
+
+### Single-stack deployment
+
+Deploy individual applications to a single AWS account. Use the Quick Create
+links above, `sam deploy`, or Terraform. Each packaged template is
+self-contained with Lambda code defaults pre-populated.
+
+### StackSet deployment (AWS Organizations)
+
+Deploy across multiple accounts and regions using CloudFormation StackSets.
+The repository includes StackSet wrapper templates:
+
+- `logwriter-stackset` -- deploys LogWriter across member accounts
+- `metricstream-stackset` -- deploys MetricStream across member accounts
+- `externalrole-stackset` -- deploys the external IAM role and PollerConfigurator
+
+Each StackSet template references the underlying app template via a
+`TemplateURL` parameter pointing to the packaged template on S3.
+
 ## Getting Started
 
 To begin using these applications, you'll need to have the AWS CLI and SAM CLI installed and configured. See below for quick instructions on building and deploying an application. For a full development guide, check out the `DEVELOPER.md` file.
@@ -47,12 +69,15 @@ To begin using these applications, you'll need to have the AWS CLI and SAM CLI i
 
 ### Building and Deploying an Application
 
-Navigate to an application's directory under `apps/` and use the SAM CLI to build and deploy:
+Package and deploy any application:
 
 ```sh
-cd apps/forwarder
-sam build
-sam deploy --guided
+make sam-package-forwarder
+# deploy the packaged template
+sam deploy \
+  --template .aws-sam/build/regions/${AWS_REGION}/forwarder.yaml \
+  --stack-name my-forwarder \
+  --capabilities CAPABILITY_IAM CAPABILITY_AUTO_EXPAND
 ```
 
 For more detailed instructions on building, deploying, and publishing applications, please see the corresponding documentation in the `docs` folder.
@@ -75,7 +100,9 @@ Each SAM application has its own documentation, providing specific details and u
 - [Forwarder](docs/forwarder.md)
 - [MetricStream](docs/metricstream.md)
 - [LogWriter](docs/logwriter.md)
+- [ExternalRole](docs/externalrole.md)
 - [Config](docs/config.md)
+- [ConfigSubscription](docs/configsubscription.md)
 
 For development practices, build and release processes, and testing workflows, see the `DEVELOPER.md` file.
 

--- a/apps/externalrole-stackset/template.yaml
+++ b/apps/externalrole-stackset/template.yaml
@@ -1,0 +1,230 @@
+---
+AWSTemplateFormatVersion: '2010-09-09'
+Description: >-
+  StackSet for deploying Observe ExternalRole across an AWS Organization.
+  Deploy this template in the management or delegated admin account.
+
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
+          default: StackSet Configuration
+        Parameters:
+          - TemplateURL
+          - TargetOUs
+          - TargetRegions
+          - AutoDeployEnabled
+          - RetainStacksOnAccountRemoval
+          - CallAs
+      - Label:
+          default: StackSet Operation Preferences
+        Parameters:
+          - MaxConcurrentPercentage
+          - FailureTolerancePercentage
+          - RegionConcurrencyType
+      - Label:
+          default: Role Configuration
+        Parameters:
+          - ObserveAwsAccountId
+          - AllowedActions
+          - DatastreamIds
+          - NameOverride
+          - PrimaryRegion
+      - Label:
+          default: Poller Configuration
+        Parameters:
+          - ObserveCustomerAccountId
+          - ObserveDomainName
+          - WorkspaceID
+          - GQLToken
+          - PollerConfigURI
+          - UpdateTimestamp
+Parameters:
+  TemplateURL:
+    Type: String
+    Description: >-
+      S3 URL of the packaged externalrole template. This is the URL produced
+      by `sam package` or `sam push`, e.g.
+      https://<bucket>.s3.<region>.amazonaws.com/aws-sam-apps/<version>/externalrole.yaml
+    AllowedPattern: "^https://.*$"
+  TargetOUs:
+    Type: CommaDelimitedList
+    Description: >-
+      Organizational Unit IDs to deploy to, e.g. ou-abc123,ou-def456.
+  TargetRegions:
+    Type: CommaDelimitedList
+    Description: >-
+      AWS Regions to deploy stack instances to, e.g. us-east-1,us-west-2.
+  AutoDeployEnabled:
+    Type: String
+    Default: 'true'
+    AllowedValues:
+      - 'true'
+      - 'false'
+    Description: >-
+      Automatically deploy to new accounts added to the target OUs.
+  RetainStacksOnAccountRemoval:
+    Type: String
+    Default: 'false'
+    AllowedValues:
+      - 'true'
+      - 'false'
+    Description: >-
+      Whether to retain stack instances when an account is removed from the
+      target OUs.
+  CallAs:
+    Type: String
+    Default: SELF
+    AllowedValues:
+      - SELF
+      - DELEGATED_ADMIN
+    Description: >-
+      Whether you are acting as the management account (SELF) or a delegated
+      administrator (DELEGATED_ADMIN).
+  MaxConcurrentPercentage:
+    Type: Number
+    Default: 100
+    MinValue: 1
+    MaxValue: 100
+    Description: >-
+      Maximum percentage of accounts in which to perform this operation at one
+      time. A value of 100 deploys to all accounts simultaneously.
+  FailureTolerancePercentage:
+    Type: Number
+    Default: 100
+    MinValue: 0
+    MaxValue: 100
+    Description: >-
+      Percentage of accounts per region for which stack operations can fail
+      before StackSets stops the operation in that region.
+  RegionConcurrencyType:
+    Type: String
+    Default: PARALLEL
+    AllowedValues:
+      - SEQUENTIAL
+      - PARALLEL
+    Description: >-
+      Whether to deploy to regions in parallel or sequentially.
+
+  # --- Pass-through parameters for externalrole ---
+  ObserveAwsAccountId:
+    Type: String
+    Description: >-
+      Observe AWS Account ID which will be allowed to assume role.
+    AllowedPattern: '\d+'
+  AllowedActions:
+    Type: CommaDelimitedList
+    Description: >-
+      IAM actions that Observe account is allowed to execute.
+  DatastreamIds:
+    Type: CommaDelimitedList
+    Description: >-
+      Datastream IDs where data will be ingested to. This ensures Observe
+      cannot assume this role outside of this context.
+  NameOverride:
+    Type: String
+    Description: >-
+      Name of IAM role expected by Poller. In the absence of a value, the
+      stack name will be used.
+    Default: ''
+    MaxLength: 64
+  PrimaryRegion:
+    Type: String
+    Description: >-
+      Region where the IAM role is created. IAM roles are
+      global, so only one region should create the role to avoid
+      conflicts. Must match one of the TargetRegions.
+    Default: 'us-west-2'
+
+  # --- Poller configuration pass-through ---
+  ObserveCustomerAccountId:
+    Type: String
+    Description: >-
+      Observe customer account ID for the GQL API (e.g. 117606320593).
+    Default: ''
+  ObserveDomainName:
+    Type: String
+    Description: >-
+      Observe domain name for the GQL API (e.g. observeinc.com).
+    Default: ''
+  WorkspaceID:
+    Type: String
+    Description: >-
+      Observe workspace ID where the poller will be created.
+    Default: ''
+  GQLToken:
+    Type: String
+    NoEcho: true
+    Description: >-
+      GQL token with poller CRUD permissions.
+    Default: ''
+  PollerConfigURI:
+    Type: String
+    Description: >-
+      S3 URI pointing to the poller configuration JSON file
+      (e.g. s3://mybucket/poller-config.json).
+    Default: ''
+  UpdateTimestamp:
+    Type: String
+    Description: >-
+      Change this value to force the PollerConfigurator custom resource
+      to re-run on stack update.
+    Default: ''
+    AllowedPattern: '^[0-9]*$'
+Resources:
+  ExternalRoleStackSet:
+    Type: AWS::CloudFormation::StackSet
+    Properties:
+      StackSetName: !Sub '${AWS::StackName}'
+      Description: >-
+        Observe ExternalRole - creates an IAM role allowing Observe to assume
+        it for metrics polling, with optional poller configuration.
+      TemplateURL: !Ref TemplateURL
+      PermissionModel: SERVICE_MANAGED
+      CallAs: !Ref CallAs
+      AutoDeployment:
+        Enabled: !Ref AutoDeployEnabled
+        RetainStacksOnAccountRemoval: !Ref RetainStacksOnAccountRemoval
+      Capabilities:
+        - CAPABILITY_IAM
+        - CAPABILITY_NAMED_IAM
+      ManagedExecution:
+        Active: true
+      OperationPreferences:
+        MaxConcurrentPercentage: !Ref MaxConcurrentPercentage
+        FailureTolerancePercentage: !Ref FailureTolerancePercentage
+        RegionConcurrencyType: !Ref RegionConcurrencyType
+      StackInstancesGroup:
+        - DeploymentTargets:
+            OrganizationalUnitIds: !Ref TargetOUs
+          Regions: !Ref TargetRegions
+      Parameters:
+        - ParameterKey: ObserveAwsAccountId
+          ParameterValue: !Ref ObserveAwsAccountId
+        - ParameterKey: AllowedActions
+          ParameterValue: !Join [',', !Ref AllowedActions]
+        - ParameterKey: DatastreamIds
+          ParameterValue: !Join [',', !Ref DatastreamIds]
+        - ParameterKey: NameOverride
+          ParameterValue: !Ref NameOverride
+        - ParameterKey: PrimaryRegion
+          ParameterValue: !Ref PrimaryRegion
+        - ParameterKey: ObserveCustomerAccountId
+          ParameterValue: !Ref ObserveCustomerAccountId
+        - ParameterKey: ObserveDomainName
+          ParameterValue: !Ref ObserveDomainName
+        - ParameterKey: WorkspaceID
+          ParameterValue: !Ref WorkspaceID
+        - ParameterKey: GQLToken
+          ParameterValue: !Ref GQLToken
+        - ParameterKey: PollerConfigURI
+          ParameterValue: !Ref PollerConfigURI
+        - ParameterKey: UpdateTimestamp
+          ParameterValue: !Ref UpdateTimestamp
+Outputs:
+  StackSetName:
+    Description: Name of the ExternalRole StackSet.
+    Value: !Sub '${AWS::StackName}'
+  StackSetId:
+    Description: ID of the ExternalRole StackSet.
+    Value: !Ref ExternalRoleStackSet

--- a/apps/externalrole-stackset/template.yaml
+++ b/apps/externalrole-stackset/template.yaml
@@ -96,7 +96,14 @@ Parameters:
     MaxValue: 100
     Description: >-
       Percentage of accounts per region for which stack operations can fail
-      before StackSets stops the operation in that region.
+      before StackSets stops the operation in that region. AWS requires
+      FailureTolerancePercentage + 1 >= MaxConcurrentPercentage, so this
+      defaults to 100 to enable full parallelism. NOTE: with 100, the
+      StackSet operation reports SUCCEEDED even if every instance failed.
+      Always check per-instance status after deploy: in the AWS console,
+      open CloudFormation > StackSets > (this stackset) > Stack instances
+      tab; or via CLI: `aws cloudformation list-stack-instances
+      --stack-set-name <name>`.
   RegionConcurrencyType:
     Type: String
     Default: PARALLEL

--- a/apps/externalrole-stackset/template.yaml
+++ b/apps/externalrole-stackset/template.yaml
@@ -128,6 +128,7 @@ Parameters:
     Description: >-
       Datastream IDs where data will be ingested to. This ensures Observe
       cannot assume this role outside of this context.
+    AllowedPattern: '\d+'
   NameOverride:
     Type: String
     Description: >-

--- a/apps/externalrole-stackset/template.yaml
+++ b/apps/externalrole-stackset/template.yaml
@@ -124,8 +124,10 @@ Parameters:
   NameOverride:
     Type: String
     Description: >-
-      Name of IAM role expected by Poller. In the absence of a value, the
-      stack name will be used.
+      Name of IAM role expected by Poller. If empty, the wrapper stack's
+      own name is passed through (so resource names do not exceed AWS's
+      64-char limit when the StackSet auto-generates the inner stack name
+      as `StackSet-<wrapper>-<uuid>`).
     Default: ''
     MaxLength: 64
   PrimaryRegion:
@@ -171,6 +173,11 @@ Parameters:
       to re-run on stack update.
     Default: ''
     AllowedPattern: '^[0-9]*$'
+Conditions:
+  HasNameOverride: !Not
+    - !Equals
+      - !Ref NameOverride
+      - ''
 Resources:
   ExternalRoleStackSet:
     Type: AWS::CloudFormation::StackSet
@@ -206,7 +213,10 @@ Resources:
         - ParameterKey: DatastreamIds
           ParameterValue: !Join [',', !Ref DatastreamIds]
         - ParameterKey: NameOverride
-          ParameterValue: !Ref NameOverride
+          ParameterValue: !If
+            - HasNameOverride
+            - !Ref NameOverride
+            - !Ref 'AWS::StackName'
         - ParameterKey: PrimaryRegion
           ParameterValue: !Ref PrimaryRegion
         - ParameterKey: ObserveCustomerAccountId

--- a/apps/logwriter-stackset/template.yaml
+++ b/apps/logwriter-stackset/template.yaml
@@ -1,0 +1,283 @@
+---
+AWSTemplateFormatVersion: '2010-09-09'
+Description: >-
+  StackSet for deploying Observe LogWriter across an AWS Organization.
+  Deploy this template in the management or delegated admin account.
+
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
+          default: StackSet Configuration
+        Parameters:
+          - TemplateURL
+          - TargetOUs
+          - TargetRegions
+          - AutoDeployEnabled
+          - RetainStacksOnAccountRemoval
+          - CallAs
+      - Label:
+          default: StackSet Operation Preferences
+        Parameters:
+          - MaxConcurrentPercentage
+          - FailureTolerancePercentage
+          - RegionConcurrencyType
+      - Label:
+          default: LogWriter Destination
+        Parameters:
+          - BucketArn
+          - Prefix
+      - Label:
+          default: LogWriter Subscription
+        Parameters:
+          - LogGroupNamePatterns
+          - LogGroupNamePrefixes
+          - ExcludeLogGroupNamePatterns
+          - DiscoveryRate
+          - FilterName
+          - FilterPattern
+          - NameOverride
+      - Label:
+          default: LogWriter Sizing
+        Parameters:
+          - BufferingInterval
+          - BufferingSize
+          - NumWorkers
+          - MemorySize
+          - Timeout
+      - Label:
+          default: LogWriter Debugging
+        Parameters:
+          - DebugEndpoint
+          - Verbosity
+
+Parameters:
+  TemplateURL:
+    Type: String
+    Description: >-
+      S3 URL of the packaged logwriter template. This is the URL produced by
+      `sam package` or `sam push`, e.g.
+      https://<bucket>.s3.<region>.amazonaws.com/aws-sam-apps/<version>/logwriter.yaml
+    AllowedPattern: "^https://.*$"
+  TargetOUs:
+    Type: CommaDelimitedList
+    Description: >-
+      Organizational Unit IDs to deploy to, e.g. ou-abc123,ou-def456.
+  TargetRegions:
+    Type: CommaDelimitedList
+    Description: >-
+      AWS Regions to deploy stack instances to, e.g. us-east-1,us-west-2.
+  AutoDeployEnabled:
+    Type: String
+    Default: 'true'
+    AllowedValues:
+      - 'true'
+      - 'false'
+    Description: >-
+      Automatically deploy to new accounts added to the target OUs.
+  RetainStacksOnAccountRemoval:
+    Type: String
+    Default: 'false'
+    AllowedValues:
+      - 'true'
+      - 'false'
+    Description: >-
+      Whether to retain stack instances when an account is removed from the
+      target OUs.
+  CallAs:
+    Type: String
+    Default: SELF
+    AllowedValues:
+      - SELF
+      - DELEGATED_ADMIN
+    Description: >-
+      Whether you are acting as the management account (SELF) or a delegated
+      administrator (DELEGATED_ADMIN).
+  MaxConcurrentPercentage:
+    Type: Number
+    Default: 100
+    MinValue: 1
+    MaxValue: 100
+    Description: >-
+      Maximum percentage of accounts in which to perform this operation at one
+      time. A value of 100 deploys to all accounts simultaneously.
+  FailureTolerancePercentage:
+    Type: Number
+    Default: 100
+    MinValue: 0
+    MaxValue: 100
+    Description: >-
+      Percentage of accounts per region for which stack operations can fail
+      before StackSets stops the operation in that region.
+  RegionConcurrencyType:
+    Type: String
+    Default: PARALLEL
+    AllowedValues:
+      - SEQUENTIAL
+      - PARALLEL
+    Description: >-
+      Whether to deploy to regions in parallel or sequentially.
+
+  # --- Pass-through parameters for logwriter ---
+  BucketArn:
+    Type: String
+    Description: >-
+      S3 Bucket ARN to write log records to.
+    AllowedPattern: "^arn:.*"
+  Prefix:
+    Type: String
+    Description: >-
+      Optional prefix to write log records to.
+    Default: ''
+  LogGroupNamePatterns:
+    Type: CommaDelimitedList
+    Description: >-
+      Comma separated list of patterns. We will only subscribe to log groups
+      that have names matching any of the provided strings based on a
+      case-sensitive substring search. Use * to subscribe to all log groups.
+    Default: ''
+  LogGroupNamePrefixes:
+    Type: CommaDelimitedList
+    Description: >-
+      Comma separated list of prefixes. The lambda function will only apply to
+      log groups that start with a provided string. Use * to subscribe to all.
+    Default: ''
+  ExcludeLogGroupNamePatterns:
+    Type: CommaDelimitedList
+    Description: >-
+      Comma separated list of patterns to filter out log groups from
+      subscription. Supports regular expressions.
+    Default: ''
+  DiscoveryRate:
+    Type: String
+    Description: >-
+      EventBridge rate expression for periodically triggering discovery.
+      If not set, no eventbridge rules are configured.
+    Default: ''
+  FilterName:
+    Type: String
+    Description: >-
+      Subscription filter name. Existing filters that have this name as a
+      prefix will be removed.
+    Default: ''
+  FilterPattern:
+    Type: String
+    Description: >-
+      Subscription filter pattern.
+    Default: ''
+  NameOverride:
+    Type: String
+    Description: >-
+      Name of Lambda function.
+    Default: ''
+    MaxLength: 64
+  BufferingInterval:
+    Type: Number
+    Default: 60
+    MinValue: 60
+    MaxValue: 900
+    Description: >-
+      Buffer incoming data for the specified period of time, in seconds,
+      before delivering it to S3.
+  BufferingSize:
+    Type: Number
+    Default: 1
+    MinValue: 1
+    MaxValue: 64
+    Description: >-
+      Buffer incoming data to the specified size, in MiBs, before delivering
+      it to S3.
+  NumWorkers:
+    Type: String
+    Description: >-
+      Maximum number of concurrent workers when processing log groups.
+    Default: ''
+  MemorySize:
+    Type: String
+    Description: >-
+      The amount of memory, in megabytes, that your function has access to.
+    Default: ''
+  Timeout:
+    Type: String
+    Description: >-
+      The amount of time that Lambda allows a function to run before stopping
+      it. The maximum allowed value is 900 seconds.
+    Default: ''
+  DebugEndpoint:
+    Type: String
+    Description: >-
+      Endpoint to send additional debug telemetry to.
+    Default: ''
+  Verbosity:
+    Type: String
+    Default: ''
+    Description: >-
+      Logging verbosity for Lambda. Highest log verbosity is 9.
+Resources:
+  LogWriterStackSet:
+    Type: AWS::CloudFormation::StackSet
+    Properties:
+      StackSetName: !Sub '${AWS::StackName}'
+      Description: >-
+        Observe LogWriter - subscribes CloudWatch Log Groups and writes logs
+        to S3 via Kinesis Firehose.
+      TemplateURL: !Ref TemplateURL
+      PermissionModel: SERVICE_MANAGED
+      CallAs: !Ref CallAs
+      AutoDeployment:
+        Enabled: !Ref AutoDeployEnabled
+        RetainStacksOnAccountRemoval: !Ref RetainStacksOnAccountRemoval
+      Capabilities:
+        - CAPABILITY_IAM
+        - CAPABILITY_NAMED_IAM
+      ManagedExecution:
+        Active: true
+      OperationPreferences:
+        MaxConcurrentPercentage: !Ref MaxConcurrentPercentage
+        FailureTolerancePercentage: !Ref FailureTolerancePercentage
+        RegionConcurrencyType: !Ref RegionConcurrencyType
+      StackInstancesGroup:
+        - DeploymentTargets:
+            OrganizationalUnitIds: !Ref TargetOUs
+          Regions: !Ref TargetRegions
+      Parameters:
+        - ParameterKey: BucketArn
+          ParameterValue: !Ref BucketArn
+        - ParameterKey: Prefix
+          ParameterValue: !Ref Prefix
+        - ParameterKey: LogGroupNamePatterns
+          ParameterValue: !Join [',', !Ref LogGroupNamePatterns]
+        - ParameterKey: LogGroupNamePrefixes
+          ParameterValue: !Join [',', !Ref LogGroupNamePrefixes]
+        - ParameterKey: ExcludeLogGroupNamePatterns
+          ParameterValue: !Join [',', !Ref ExcludeLogGroupNamePatterns]
+        - ParameterKey: DiscoveryRate
+          ParameterValue: !Ref DiscoveryRate
+        - ParameterKey: FilterName
+          ParameterValue: !Ref FilterName
+        - ParameterKey: FilterPattern
+          ParameterValue: !Ref FilterPattern
+        - ParameterKey: NameOverride
+          ParameterValue: !Ref NameOverride
+        - ParameterKey: BufferingInterval
+          ParameterValue: !Ref BufferingInterval
+        - ParameterKey: BufferingSize
+          ParameterValue: !Ref BufferingSize
+        - ParameterKey: NumWorkers
+          ParameterValue: !Ref NumWorkers
+        - ParameterKey: MemorySize
+          ParameterValue: !Ref MemorySize
+        - ParameterKey: Timeout
+          ParameterValue: !Ref Timeout
+        - ParameterKey: DebugEndpoint
+          ParameterValue: !Ref DebugEndpoint
+        - ParameterKey: Verbosity
+          ParameterValue: !Ref Verbosity
+
+Outputs:
+  StackSetName:
+    Description: Name of the LogWriter StackSet.
+    Value: !Sub '${AWS::StackName}'
+  StackSetId:
+    Description: ID of the LogWriter StackSet.
+    Value: !Ref LogWriterStackSet

--- a/apps/logwriter-stackset/template.yaml
+++ b/apps/logwriter-stackset/template.yaml
@@ -143,12 +143,14 @@ Parameters:
       that have names matching any of the provided strings based on a
       case-sensitive substring search. Use * to subscribe to all log groups.
     Default: ''
+    AllowedPattern: '^(\*|[a-zA-Z0-9-_\/]*)$'
   LogGroupNamePrefixes:
     Type: CommaDelimitedList
     Description: >-
       Comma separated list of prefixes. The lambda function will only apply to
       log groups that start with a provided string. Use * to subscribe to all.
     Default: ''
+    AllowedPattern: '^(\*|[a-zA-Z0-9-_\/]*)$'
   ExcludeLogGroupNamePatterns:
     Type: CommaDelimitedList
     Description: >-
@@ -204,27 +206,42 @@ Parameters:
     Description: >-
       Maximum number of concurrent workers when processing log groups.
     Default: ''
+    AllowedPattern: '^[0-9]*$'
   MemorySize:
     Type: String
     Description: >-
       The amount of memory, in megabytes, that your function has access to.
     Default: ''
+    AllowedValues:
+      - ''
+      - '64'
+      - '128'
+      - '256'
+      - '512'
+      - '1024'
+      - '2048'
+      - '4096'
+      - '8128'
+    AllowedPattern: "^[0-9]*$"
   Timeout:
     Type: String
     Description: >-
       The amount of time that Lambda allows a function to run before stopping
       it. The maximum allowed value is 900 seconds.
     Default: ''
+    AllowedPattern: "^[0-9]*$"
   DebugEndpoint:
     Type: String
     Description: >-
       Endpoint to send additional debug telemetry to.
     Default: ''
+    AllowedPattern: '^(http(s)?://.*)?$'
   Verbosity:
     Type: String
     Default: ''
     Description: >-
       Logging verbosity for Lambda. Highest log verbosity is 9.
+    AllowedPattern: "^[0-9]?$"
 Conditions:
   HasNameOverride: !Not
     - !Equals

--- a/apps/logwriter-stackset/template.yaml
+++ b/apps/logwriter-stackset/template.yaml
@@ -158,9 +158,11 @@ Parameters:
   DiscoveryRate:
     Type: String
     Description: >-
-      EventBridge rate expression for periodically triggering discovery.
-      If not set, no eventbridge rules are configured.
+      Rate at which the subscriber Lambda re-scans for log groups, e.g.
+      "5 minutes" or "1 hour". Pass only the rate body (not the full
+      "rate(...)" expression). Leave empty to disable scheduled discovery.
     Default: ''
+    AllowedPattern: '^([1-9]\d* (minute|hour|day)s?)?$'
   FilterName:
     Type: String
     Description: >-

--- a/apps/logwriter-stackset/template.yaml
+++ b/apps/logwriter-stackset/template.yaml
@@ -168,7 +168,10 @@ Parameters:
   NameOverride:
     Type: String
     Description: >-
-      Name of Lambda function.
+      Name of Lambda function. If empty, the wrapper stack's own name is
+      passed through (so resource names do not exceed AWS's 64-char limit
+      when the StackSet auto-generates the inner stack name as
+      `StackSet-<wrapper>-<uuid>`).
     Default: ''
     MaxLength: 64
   BufferingInterval:
@@ -213,6 +216,11 @@ Parameters:
     Default: ''
     Description: >-
       Logging verbosity for Lambda. Highest log verbosity is 9.
+Conditions:
+  HasNameOverride: !Not
+    - !Equals
+      - !Ref NameOverride
+      - ''
 Resources:
   LogWriterStackSet:
     Type: AWS::CloudFormation::StackSet
@@ -258,7 +266,10 @@ Resources:
         - ParameterKey: FilterPattern
           ParameterValue: !Ref FilterPattern
         - ParameterKey: NameOverride
-          ParameterValue: !Ref NameOverride
+          ParameterValue: !If
+            - HasNameOverride
+            - !Ref NameOverride
+            - !Ref 'AWS::StackName'
         - ParameterKey: BufferingInterval
           ParameterValue: !Ref BufferingInterval
         - ParameterKey: BufferingSize

--- a/apps/logwriter-stackset/template.yaml
+++ b/apps/logwriter-stackset/template.yaml
@@ -108,7 +108,14 @@ Parameters:
     MaxValue: 100
     Description: >-
       Percentage of accounts per region for which stack operations can fail
-      before StackSets stops the operation in that region.
+      before StackSets stops the operation in that region. AWS requires
+      FailureTolerancePercentage + 1 >= MaxConcurrentPercentage, so this
+      defaults to 100 to enable full parallelism. NOTE: with 100, the
+      StackSet operation reports SUCCEEDED even if every instance failed.
+      Always check per-instance status after deploy: in the AWS console,
+      open CloudFormation > StackSets > (this stackset) > Stack instances
+      tab; or via CLI: `aws cloudformation list-stack-instances
+      --stack-set-name <name>`.
   RegionConcurrencyType:
     Type: String
     Default: PARALLEL

--- a/apps/metricstream-stackset/template.yaml
+++ b/apps/metricstream-stackset/template.yaml
@@ -1,0 +1,250 @@
+---
+AWSTemplateFormatVersion: '2010-09-09'
+Description: >-
+  StackSet for deploying Observe MetricStream across an AWS Organization.
+  Deploy this template in the management or delegated admin account.
+
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
+          default: StackSet Configuration
+        Parameters:
+          - TemplateURL
+          - TargetOUs
+          - TargetRegions
+          - AutoDeployEnabled
+          - RetainStacksOnAccountRemoval
+          - CallAs
+      - Label:
+          default: StackSet Operation Preferences
+        Parameters:
+          - MaxConcurrentPercentage
+          - FailureTolerancePercentage
+          - RegionConcurrencyType
+      - Label:
+          default: MetricStream Destination
+        Parameters:
+          - BucketArn
+          - Prefix
+      - Label:
+          default: MetricStream Configuration
+        Parameters:
+          - FilterUri
+          - OutputFormat
+          - NameOverride
+      - Label:
+          default: MetricStream Sizing
+        Parameters:
+          - BufferingInterval
+          - BufferingSize
+      - Label:
+          default: Observe Configuration
+        Parameters:
+          - ObserveAccountID
+          - ObserveDomainName
+          - DatasourceID
+          - GQLToken
+          - UpdateTimestamp
+
+Parameters:
+  TemplateURL:
+    Type: String
+    Description: >-
+      S3 URL of the packaged metricstream template. This is the URL produced
+      by `sam package` or `sam push`, e.g.
+      https://<bucket>.s3.<region>.amazonaws.com/aws-sam-apps/<version>/metricstream.yaml
+    AllowedPattern: "^https://.*$"
+  TargetOUs:
+    Type: CommaDelimitedList
+    Description: >-
+      Organizational Unit IDs to deploy to, e.g. ou-abc123,ou-def456.
+  TargetRegions:
+    Type: CommaDelimitedList
+    Description: >-
+      AWS Regions to deploy stack instances to, e.g. us-east-1,us-west-2.
+  AutoDeployEnabled:
+    Type: String
+    Default: 'true'
+    AllowedValues:
+      - 'true'
+      - 'false'
+    Description: >-
+      Automatically deploy to new accounts added to the target OUs.
+  RetainStacksOnAccountRemoval:
+    Type: String
+    Default: 'false'
+    AllowedValues:
+      - 'true'
+      - 'false'
+    Description: >-
+      Whether to retain stack instances when an account is removed from the
+      target OUs.
+  CallAs:
+    Type: String
+    Default: SELF
+    AllowedValues:
+      - SELF
+      - DELEGATED_ADMIN
+    Description: >-
+      Whether you are acting as the management account (SELF) or a delegated
+      administrator (DELEGATED_ADMIN).
+  MaxConcurrentPercentage:
+    Type: Number
+    Default: 100
+    MinValue: 1
+    MaxValue: 100
+    Description: >-
+      Maximum percentage of accounts in which to perform this operation at one
+      time. A value of 100 deploys to all accounts simultaneously.
+  FailureTolerancePercentage:
+    Type: Number
+    Default: 100
+    MinValue: 0
+    MaxValue: 100
+    Description: >-
+      Percentage of accounts per region for which stack operations can fail
+      before StackSets stops the operation in that region.
+  RegionConcurrencyType:
+    Type: String
+    Default: PARALLEL
+    AllowedValues:
+      - SEQUENTIAL
+      - PARALLEL
+    Description: >-
+      Whether to deploy to regions in parallel or sequentially.
+
+  # --- Pass-through parameters for metricstream ---
+  BucketArn:
+    Type: String
+    Description: >-
+      S3 Bucket ARN to write metrics to.
+    AllowedPattern: "^arn:.*$"
+  Prefix:
+    Type: String
+    Description: >-
+      Optional prefix to write metrics to.
+    Default: ''
+  FilterUri:
+    Type: String
+    Description: >-
+      A file hosted in S3 containing list of metrics to stream.
+    Default: 's3://observeinc/cloudwatchmetrics/filters/empty.yaml'
+  OutputFormat:
+    Type: String
+    Description: >-
+      The output format for CloudWatch Metrics.
+    Default: 'json'
+    AllowedValues:
+      - json
+      - opentelemetry0.7
+      - opentelemetry1.0
+  NameOverride:
+    Type: String
+    Description: >-
+      Set Firehose Delivery Stream name. In the absence of a value, the stack
+      name will be used.
+    Default: ''
+    MaxLength: 64
+  BufferingInterval:
+    Type: Number
+    Default: 60
+    MinValue: 60
+    MaxValue: 900
+    Description: >-
+      Buffer incoming data for the specified period of time, in seconds,
+      before delivering it to the destination.
+  BufferingSize:
+    Type: Number
+    Default: 1
+    MinValue: 1
+    MaxValue: 64
+    Description: >-
+      Buffer incoming data to the specified size, in MiBs, before delivering
+      it to the destination.
+  ObserveAccountID:
+    Type: String
+    Description: Observe Account ID.
+    Default: ''
+  ObserveDomainName:
+    Type: String
+    Description: >-
+      The domain name we will retrieve metric configuration from.
+    Default: ''
+  UpdateTimestamp:
+    Type: String
+    Description: >-
+      Timestamp when the metric stream was created or updated.
+    Default: ''
+  DatasourceID:
+    Type: String
+    Description: >-
+      The datasource for this metric stream. Providing this will override the
+      MetricStreamFilterUri.
+    Default: ''
+  GQLToken:
+    Type: String
+    NoEcho: true
+    Description: >-
+      The token used to retrieve metric configuration.
+    Default: ''
+Resources:
+  MetricStreamStackSet:
+    Type: AWS::CloudFormation::StackSet
+    Properties:
+      StackSetName: !Sub '${AWS::StackName}'
+      Description: >-
+        Observe MetricStream - streams CloudWatch Metrics to S3 via Kinesis
+        Firehose.
+      TemplateURL: !Ref TemplateURL
+      PermissionModel: SERVICE_MANAGED
+      CallAs: !Ref CallAs
+      AutoDeployment:
+        Enabled: !Ref AutoDeployEnabled
+        RetainStacksOnAccountRemoval: !Ref RetainStacksOnAccountRemoval
+      Capabilities:
+        - CAPABILITY_IAM
+        - CAPABILITY_NAMED_IAM
+      ManagedExecution:
+        Active: true
+      OperationPreferences:
+        MaxConcurrentPercentage: !Ref MaxConcurrentPercentage
+        FailureTolerancePercentage: !Ref FailureTolerancePercentage
+        RegionConcurrencyType: !Ref RegionConcurrencyType
+      StackInstancesGroup:
+        - DeploymentTargets:
+            OrganizationalUnitIds: !Ref TargetOUs
+          Regions: !Ref TargetRegions
+      Parameters:
+        - ParameterKey: BucketArn
+          ParameterValue: !Ref BucketArn
+        - ParameterKey: Prefix
+          ParameterValue: !Ref Prefix
+        - ParameterKey: FilterUri
+          ParameterValue: !Ref FilterUri
+        - ParameterKey: OutputFormat
+          ParameterValue: !Ref OutputFormat
+        - ParameterKey: NameOverride
+          ParameterValue: !Ref NameOverride
+        - ParameterKey: BufferingInterval
+          ParameterValue: !Ref BufferingInterval
+        - ParameterKey: BufferingSize
+          ParameterValue: !Ref BufferingSize
+        - ParameterKey: ObserveAccountID
+          ParameterValue: !Ref ObserveAccountID
+        - ParameterKey: ObserveDomainName
+          ParameterValue: !Ref ObserveDomainName
+        - ParameterKey: UpdateTimestamp
+          ParameterValue: !Ref UpdateTimestamp
+        - ParameterKey: DatasourceID
+          ParameterValue: !Ref DatasourceID
+        - ParameterKey: GQLToken
+          ParameterValue: !Ref GQLToken
+
+Outputs:
+  StackSetName:
+    Description: Name of the MetricStream StackSet.
+    Value: !Sub '${AWS::StackName}'
+  StackSetId:
+    Description: ID of the MetricStream StackSet.
+    Value: !Ref MetricStreamStackSet

--- a/apps/metricstream-stackset/template.yaml
+++ b/apps/metricstream-stackset/template.yaml
@@ -104,7 +104,14 @@ Parameters:
     MaxValue: 100
     Description: >-
       Percentage of accounts per region for which stack operations can fail
-      before StackSets stops the operation in that region.
+      before StackSets stops the operation in that region. AWS requires
+      FailureTolerancePercentage + 1 >= MaxConcurrentPercentage, so this
+      defaults to 100 to enable full parallelism. NOTE: with 100, the
+      StackSet operation reports SUCCEEDED even if every instance failed.
+      Always check per-instance status after deploy: in the AWS console,
+      open CloudFormation > StackSets > (this stackset) > Stack instances
+      tab; or via CLI: `aws cloudformation list-stack-instances
+      --stack-set-name <name>`.
   RegionConcurrencyType:
     Type: String
     Default: PARALLEL

--- a/apps/metricstream-stackset/template.yaml
+++ b/apps/metricstream-stackset/template.yaml
@@ -142,8 +142,10 @@ Parameters:
   NameOverride:
     Type: String
     Description: >-
-      Set Firehose Delivery Stream name. In the absence of a value, the stack
-      name will be used.
+      Set Firehose Delivery Stream name. If empty, the wrapper stack's own
+      name is passed through (so resource names do not exceed AWS's 64-char
+      limit when the StackSet auto-generates the inner stack name as
+      `StackSet-<wrapper>-<uuid>`).
     Default: ''
     MaxLength: 64
   BufferingInterval:
@@ -188,6 +190,11 @@ Parameters:
     Description: >-
       The token used to retrieve metric configuration.
     Default: ''
+Conditions:
+  HasNameOverride: !Not
+    - !Equals
+      - !Ref NameOverride
+      - ''
 Resources:
   MetricStreamStackSet:
     Type: AWS::CloudFormation::StackSet
@@ -225,7 +232,10 @@ Resources:
         - ParameterKey: OutputFormat
           ParameterValue: !Ref OutputFormat
         - ParameterKey: NameOverride
-          ParameterValue: !Ref NameOverride
+          ParameterValue: !If
+            - HasNameOverride
+            - !Ref NameOverride
+            - !Ref 'AWS::StackName'
         - ParameterKey: BufferingInterval
           ParameterValue: !Ref BufferingInterval
         - ParameterKey: BufferingSize

--- a/apps/metricstream-stackset/template.yaml
+++ b/apps/metricstream-stackset/template.yaml
@@ -137,6 +137,7 @@ Parameters:
     Description: >-
       A file hosted in S3 containing list of metrics to stream.
     Default: 's3://observeinc/cloudwatchmetrics/filters/empty.yaml'
+    AllowedPattern: '^(s3://.*)?$'
   OutputFormat:
     Type: String
     Description: >-
@@ -175,6 +176,7 @@ Parameters:
     Type: String
     Description: Observe Account ID.
     Default: ''
+    AllowedPattern: '\d*'
   ObserveDomainName:
     Type: String
     Description: >-
@@ -185,12 +187,14 @@ Parameters:
     Description: >-
       Timestamp when the metric stream was created or updated.
     Default: ''
+    AllowedPattern: '^[0-9]*$'
   DatasourceID:
     Type: String
     Description: >-
       The datasource for this metric stream. Providing this will override the
       MetricStreamFilterUri.
     Default: ''
+    AllowedPattern: '\d*'
   GQLToken:
     Type: String
     NoEcho: true

--- a/docs/multi-account.md
+++ b/docs/multi-account.md
@@ -1,0 +1,274 @@
+# Multi-Account Deployment with StackSets
+
+The logwriter, metricstream, and externalrole templates each have a
+corresponding `-stackset` variant that deploys the app across an AWS
+Organization using CloudFormation StackSets. This document covers
+cross-cutting concerns common to all three.
+
+For stack-specific parameters and behavior, see the individual docs:
+- [LogWriter](logwriter.md)
+- [MetricStream](metricstream.md)
+- [ExternalRole](externalrole.md)
+
+For local development and packaging workflows, see [DEVELOPER.md](../DEVELOPER.md).
+
+## Prerequisites
+
+1. **AWS Organizations management account** (or a delegated administrator
+   account). The stackset templates use `SERVICE_MANAGED` permission model.
+2. **A target Organizational Unit (OU)** containing at least one member
+   account. You need the OU ID (e.g. `ou-xxxx-xxxxxxxx`).
+3. **A central S3 bucket** in the management account where Firehose delivery
+   streams in member accounts will write data. This bucket requires a
+   cross-account bucket policy (see below).
+4. **A Forwarder stack** deployed in the management account, watching the
+   central bucket and forwarding data to Observe. The stacksets do not deploy
+   a Forwarder.
+5. **IAM capabilities**: all stackset deployments require `CAPABILITY_IAM`,
+   `CAPABILITY_NAMED_IAM`, and `CAPABILITY_AUTO_EXPAND`.
+
+## Central Bucket Permissions
+
+The central S3 bucket must allow Firehose delivery streams from member
+accounts to write objects. Without this, logwriter and metricstream instances
+will fail with `Access Denied`.
+
+The bucket policy needs to grant Firehose delivery roles in member accounts
+permission to write objects and manage multipart uploads. A convenient approach
+is to use a wildcard principal scoped to your organization:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowFirehoseWriteFromOrg",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": [
+        "s3:AbortMultipartUpload",
+        "s3:GetBucketLocation",
+        "s3:GetObject",
+        "s3:ListBucket",
+        "s3:ListBucketMultipartUploads",
+        "s3:PutObject"
+      ],
+      "Resource": [
+        "arn:aws:s3:::YOUR-CENTRAL-BUCKET",
+        "arn:aws:s3:::YOUR-CENTRAL-BUCKET/*"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "aws:PrincipalOrgID": "o-YOUR-ORG-ID"
+        }
+      }
+    }
+  ]
+}
+```
+
+Replace `YOUR-CENTRAL-BUCKET` and `o-YOUR-ORG-ID` with your values. The
+`aws:PrincipalOrgID` condition ensures only accounts within your organization
+can write, without needing to enumerate individual account IDs.
+
+## Operation Preferences (Concurrency)
+
+By default, the stackset templates deploy to all accounts and regions
+simultaneously. Three parameters control this behavior:
+
+### MaxConcurrentPercentage
+
+The percentage of target accounts to deploy to at the same time. With 200
+accounts in an OU:
+
+| Value | Behavior |
+|-------|----------|
+| `100` | All 200 accounts deploy simultaneously |
+| `25`  | 50 at a time, in 4 waves |
+| `10`  | 20 at a time, in 10 waves |
+
+Default: **100** (maximum parallelism).
+
+### FailureTolerancePercentage
+
+The percentage of accounts per region that can fail before StackSets stops
+deploying to remaining accounts. This does **not** roll back accounts that
+already succeeded -- it only stops starting new ones.
+
+| Value | Behavior |
+|-------|----------|
+| `100` | All accounts are attempted regardless of failures |
+| `10`  | Stop if more than 10% of accounts fail |
+| `0`   | Stop on the first failure |
+
+Default: **100** (never abort).
+
+### RegionConcurrencyType
+
+When targeting multiple regions:
+
+| Value | Behavior |
+|-------|----------|
+| `PARALLEL`   | Deploy to all regions at the same time |
+| `SEQUENTIAL` | Finish all accounts in one region before starting the next |
+
+Default: **PARALLEL**.
+
+`SEQUENTIAL` is useful for canary deployments: put your canary region first in
+the `TargetRegions` list, and if it fully succeeds, the remaining regions
+proceed automatically.
+
+### Choosing values
+
+For most deployments, the defaults (100/100/PARALLEL) are appropriate -- deploy
+everywhere as fast as possible. For a cautious rollout:
+
+```
+MaxConcurrentPercentage=25
+FailureTolerancePercentage=10
+RegionConcurrencyType=SEQUENTIAL
+```
+
+This deploys to 25% of accounts at a time in the first region, stops if more
+than 10% fail, and only proceeds to the next region after the previous one
+completes.
+
+## Monitoring Operations
+
+### List operations on a StackSet
+
+```sh
+aws cloudformation list-stack-set-operations \
+  --stack-set-name STACKSET_NAME \
+  --region us-west-2
+```
+
+This shows running and completed operations, including the
+`OperationPreferences` that were applied.
+
+### List instance status across accounts
+
+```sh
+aws cloudformation list-stack-instances \
+  --stack-set-name STACKSET_NAME \
+  --region us-west-2 \
+  --query 'Summaries[*].[Account,Region,StackInstanceStatus.DetailedStatus,Status]' \
+  --output table
+```
+
+Status values:
+- `CURRENT` -- instance matches the latest template
+- `OUTDATED` -- instance needs updating (often due to a prior failure)
+- `RUNNING` -- operation in progress
+
+### Get details on failed instances
+
+```sh
+aws cloudformation list-stack-set-operation-results \
+  --stack-set-name STACKSET_NAME \
+  --operation-id OPERATION_ID \
+  --region us-west-2 \
+  --query 'Summaries[?Status==`FAILED`].[Account,Region,StatusReason]' \
+  --output table
+```
+
+## Handling Partial Failures
+
+A partially failed StackSet has some instances in `CURRENT` (succeeded) and
+others in `OUTDATED`/`FAILED`. The wrapper CloudFormation stack itself may
+show `CREATE_COMPLETE` or `UPDATE_COMPLETE` if `FailureTolerancePercentage`
+allowed the operation to finish.
+
+### Retry failed instances
+
+Fix the underlying issue (e.g. missing bucket policy, SCP blocking a region)
+and update the wrapper stack. StackSets will re-attempt all `OUTDATED`
+instances:
+
+```sh
+aws cloudformation update-stack \
+  --stack-name WRAPPER_STACK_NAME \
+  --use-previous-template \
+  --parameters \
+    ParameterKey=TargetOUs,UsePreviousValue=true \
+    ParameterKey=TargetRegions,UsePreviousValue=true \
+    ParameterKey=BucketArn,UsePreviousValue=true \
+    ParameterKey=NameOverride,UsePreviousValue=true \
+    ParameterKey=TemplateURL,UsePreviousValue=true \
+  --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND \
+  --region us-west-2
+```
+
+### Revert to a previous template version
+
+There is no built-in rollback for StackSets. To revert, update the wrapper
+stack with the previous `TemplateURL`:
+
+```sh
+aws cloudformation update-stack \
+  --stack-name WRAPPER_STACK_NAME \
+  --use-previous-template \
+  --parameters \
+    ParameterKey=TemplateURL,ParameterValue=https://BUCKET.s3.REGION.amazonaws.com/aws-sam-apps/PREVIOUS_VERSION/TEMPLATE.yaml \
+    ParameterKey=TargetOUs,UsePreviousValue=true \
+    ParameterKey=TargetRegions,UsePreviousValue=true \
+    ParameterKey=BucketArn,UsePreviousValue=true \
+    ParameterKey=NameOverride,UsePreviousValue=true \
+  --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND \
+  --region us-west-2
+```
+
+Successful instances are never rolled back by a sibling failure. If you need
+all accounts on the same version, you must explicitly update or delete.
+
+## Full Cleanup
+
+To tear down everything -- all stack instances across all accounts and regions,
+the StackSet, and the wrapper stack -- delete the wrapper stack:
+
+```sh
+aws cloudformation delete-stack \
+  --stack-name WRAPPER_STACK_NAME \
+  --region us-west-2
+```
+
+CloudFormation will delete all stack instances (using the template's
+`OperationPreferences`, so deletions happen in parallel by default), then
+delete the StackSet resource, then the wrapper stack.
+
+Monitor progress:
+
+```sh
+aws cloudformation describe-stacks \
+  --stack-name WRAPPER_STACK_NAME \
+  --region us-west-2 \
+  --query 'Stacks[0].StackStatus' \
+  --output text
+```
+
+If the delete gets stuck, check whether any instances failed to delete:
+
+```sh
+aws cloudformation list-stack-instances \
+  --stack-set-name STACKSET_NAME \
+  --region us-west-2 \
+  --query 'Summaries[?Status!=`CURRENT`]' \
+  --output table
+```
+
+## CLI Quoting
+
+The AWS CLI splits unquoted comma-separated values into JSON arrays. For
+`CommaDelimitedList` parameters, wrap the value in quotes:
+
+```sh
+# Correct -- value is passed as the string "us-east-1,us-west-2"
+'ParameterKey=TargetRegions,ParameterValue="us-east-1,us-west-2"'
+
+# Wrong -- CLI parses this as a list, causing a validation error
+ParameterKey=TargetRegions,ParameterValue=us-east-1,us-west-2
+```
+
+The same applies to `AllowedActions`, `DatastreamIds`, and any other
+comma-delimited parameter. Do not backslash-escape commas -- the backslashes
+end up in the parameter value.

--- a/docs/multi-account.md
+++ b/docs/multi-account.md
@@ -103,6 +103,29 @@ already succeeded -- it only stops starting new ones.
 
 Default: **100** (never abort).
 
+> **⚠️ Silent-failure warning.** With `FailureTolerancePercentage=100`, the
+> StackSet operation reports `SUCCEEDED` even if every member-account instance
+> failed. The wrapper stack's `CREATE_COMPLETE`/`UPDATE_COMPLETE` only means
+> "the operation ran"; it does **not** mean the stack instances are healthy.
+> Always check per-instance status after deploy:
+>
+> - **AWS console:** open CloudFormation → **StackSets** (left sidebar) →
+>   click the stackset name → **Stack instances** tab. Each row shows
+>   `Status` (e.g. `CURRENT`, `OUTDATED`) and `Detailed status`
+>   (e.g. `SUCCEEDED`, `FAILED`). Failed rows have a `Status reason` you can
+>   click to see the underlying cause.
+> - **CLI:**
+>   ```sh
+>   aws cloudformation list-stack-instances \
+>     --stack-set-name <name> \
+>     --query 'Summaries[].[Account,Region,Status,StackInstanceStatus.DetailedStatus]'
+>   ```
+>
+> AWS requires `MaxConcurrentPercentage <= FailureTolerancePercentage + 1`,
+> so lowering this value below 100 also caps parallelism. For full-fan-out
+> deploys (100% concurrent), you must accept the silent-failure trade-off
+> and check instance status manually.
+
 ### RegionConcurrencyType
 
 When targeting multiple regions:

--- a/docs/multi-account.md
+++ b/docs/multi-account.md
@@ -24,8 +24,8 @@ For local development and packaging workflows, see [DEVELOPER.md](../DEVELOPER.m
 4. **A Forwarder stack** deployed in the management account, watching the
    central bucket and forwarding data to Observe. The stacksets do not deploy
    a Forwarder.
-5. **IAM capabilities**: all stackset deployments require `CAPABILITY_IAM`,
-   `CAPABILITY_NAMED_IAM`, and `CAPABILITY_AUTO_EXPAND`.
+5. **IAM capabilities**: all stackset deployments require `CAPABILITY_IAM`
+   and `CAPABILITY_NAMED_IAM`.
 
 ## Central Bucket Permissions
 
@@ -218,7 +218,7 @@ aws cloudformation update-stack \
     ParameterKey=BucketArn,UsePreviousValue=true \
     ParameterKey=NameOverride,UsePreviousValue=true \
     ParameterKey=TemplateURL,UsePreviousValue=true \
-  --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND \
+  --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM \
   --region us-west-2
 ```
 
@@ -237,7 +237,7 @@ aws cloudformation update-stack \
     ParameterKey=TargetRegions,UsePreviousValue=true \
     ParameterKey=BucketArn,UsePreviousValue=true \
     ParameterKey=NameOverride,UsePreviousValue=true \
-  --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND \
+  --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM \
   --region us-west-2
 ```
 

--- a/integration/tests/externalrole.tftest.hcl
+++ b/integration/tests/externalrole.tftest.hcl
@@ -73,7 +73,6 @@ run "install" {
     capabilities = [
       "CAPABILITY_IAM",
       "CAPABILITY_NAMED_IAM",
-      "CAPABILITY_AUTO_EXPAND",
     ]
   }
 }

--- a/integration/tests/logwriter.tftest.hcl
+++ b/integration/tests/logwriter.tftest.hcl
@@ -122,7 +122,6 @@ run "install" {
     }
     capabilities = [
       "CAPABILITY_IAM",
-      "CAPABILITY_AUTO_EXPAND",
     ]
   }
 }
@@ -159,7 +158,6 @@ run "update" {
     }
     capabilities = [
       "CAPABILITY_IAM",
-      "CAPABILITY_AUTO_EXPAND",
     ]
   }
 }

--- a/integration/tests/metricstream.tftest.hcl
+++ b/integration/tests/metricstream.tftest.hcl
@@ -100,7 +100,6 @@ run "install" {
     }
     capabilities = [
       "CAPABILITY_IAM",
-      "CAPABILITY_AUTO_EXPAND",
     ]
   }
 }
@@ -116,7 +115,6 @@ run "update" {
     }
     capabilities = [
       "CAPABILITY_IAM",
-      "CAPABILITY_AUTO_EXPAND",
     ]
   }
 }

--- a/pkg/handler/s3.go
+++ b/pkg/handler/s3.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 )
 
@@ -25,12 +26,29 @@ func ParseS3URI(uri string) (bucket, key string, err error) {
 
 // GetS3Object fetches an s3://bucket/key object and returns the body as bytes.
 // The caller interprets the bytes (YAML, JSON, etc.).
+//
+// Handles cross-region buckets: discovers the bucket's region via the
+// x-amz-bucket-region header (manager.GetBucketRegion), then issues the
+// GetObject from a region-specific client. Without this, an S3 client
+// configured for the Lambda's region would 301 PermanentRedirect against a
+// bucket living elsewhere.
 func GetS3Object(ctx context.Context, awsCfg aws.Config, uri string) ([]byte, error) {
 	bucket, key, err := ParseS3URI(uri)
 	if err != nil {
 		return nil, err
 	}
 	client := s3.NewFromConfig(awsCfg)
+
+	bucketRegion, err := manager.GetBucketRegion(ctx, client, bucket)
+	if err != nil {
+		return nil, fmt.Errorf("failed to determine region for bucket %s: %w", bucket, err)
+	}
+	if bucketRegion != awsCfg.Region {
+		client = s3.NewFromConfig(awsCfg, func(o *s3.Options) {
+			o.Region = bucketRegion
+		})
+	}
+
 	out, err := client.GetObject(ctx, &s3.GetObjectInput{
 		Bucket: &bucket,
 		Key:    &key,

--- a/scripts/check-stackset-param-parity.py
+++ b/scripts/check-stackset-param-parity.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Check that each StackSet wrapper template's pass-through parameters
+mirror the parameter constraints declared in the underlying app template.
+
+For every (inner template, wrapper template) pair, this script compares
+the constraint properties (AllowedPattern, AllowedValues, MinValue,
+MaxValue, MaxLength, MinLength) of every parameter that appears in both.
+
+Outcomes:
+  WARN: a parameter exists in the inner template but not in the wrapper
+        (the wrapper deliberately doesn't surface this param). Does not
+        fail the check.
+  FAIL: a parameter exists in both, but the wrapper omits a constraint
+        the inner declares, or the constraints have different values.
+        These let invalid input through wrapper-side validation, only to
+        be caught by the inner stack instance -- which under StackSets'
+        FailureTolerancePercentage=100 default surfaces as a silent
+        per-instance failure instead of a fast fail at deploy time.
+
+Exits non-zero only on FAIL conditions.
+"""
+
+import re
+import sys
+
+CONSTRAINTS = [
+    "AllowedPattern",
+    "AllowedValues",
+    "MinValue",
+    "MaxValue",
+    "MaxLength",
+    "MinLength",
+]
+
+PAIRS = [
+    ("apps/logwriter/template.yaml",    "apps/logwriter-stackset/template.yaml"),
+    ("apps/metricstream/template.yaml", "apps/metricstream-stackset/template.yaml"),
+    ("apps/externalrole/template.yaml", "apps/externalrole-stackset/template.yaml"),
+]
+
+
+def parse_param_blocks(path):
+    """Return {param_name: param_block_text} for every parameter under
+    the top-level Parameters: section. Each block is the lines indented
+    under the parameter name, joined back with newlines."""
+    with open(path) as f:
+        lines = f.read().split("\n")
+
+    blocks = {}
+    in_params = False
+    cur_name = None
+    cur_lines = []
+    for line in lines:
+        if line.rstrip() == "Parameters:":
+            in_params = True
+            continue
+        if in_params and re.match(r"^[A-Z]", line):
+            # Top-level section after Parameters: ends the block.
+            in_params = False
+            if cur_name:
+                blocks[cur_name] = "\n".join(cur_lines)
+                cur_name = None
+            break
+        if not in_params:
+            continue
+        m = re.match(r"^  ([A-Z][a-zA-Z]*):\s*$", line)
+        if m:
+            if cur_name:
+                blocks[cur_name] = "\n".join(cur_lines)
+            cur_name = m.group(1)
+            cur_lines = []
+        else:
+            cur_lines.append(line)
+    if cur_name:
+        blocks[cur_name] = "\n".join(cur_lines)
+    return blocks
+
+
+def constraint_value(block, key):
+    """Extract a single constraint's value from a parameter block.
+    Returns None if absent. Inline values are returned as a stripped
+    string. List values (e.g. AllowedValues across several lines) are
+    normalized to a sorted bracketed string for comparison."""
+    # Try multi-line list form first (must come before the inline check
+    # because both can match an empty inline value):
+    #     AllowedValues:
+    #       - 'foo'
+    #       - 'bar'
+    list_match = re.search(
+        r"^    " + key + r":\s*$(?:\n      - [^\n]*)+",
+        block,
+        re.MULTILINE,
+    )
+    if list_match:
+        items = re.findall(r"^      - (.*)$", list_match.group(0), re.MULTILINE)
+        return "[" + ", ".join(sorted(item.strip() for item in items)) + "]"
+    # Inline form: `    AllowedPattern: '^foo$'`
+    inline = re.search(r"^    " + key + r":\s*([^\s].*)$", block, re.MULTILINE)
+    if inline:
+        return inline.group(1).strip()
+    return None
+
+
+def main():
+    warn_count = 0
+    fail_count = 0
+    for inner_path, wrapper_path in PAIRS:
+        inner = parse_param_blocks(inner_path)
+        wrapper = parse_param_blocks(wrapper_path)
+        app = inner_path.split("/")[1]
+        for name in inner:
+            if name not in wrapper:
+                print(
+                    f"WARN  {app}.{name}: in inner but not in wrapper "
+                    f"(wrapper does not surface this parameter)",
+                    file=sys.stderr,
+                )
+                warn_count += 1
+                continue
+            for key in CONSTRAINTS:
+                inner_val = constraint_value(inner[name], key)
+                wrap_val = constraint_value(wrapper[name], key)
+                if inner_val == wrap_val:
+                    continue
+                if inner_val is not None and wrap_val is None:
+                    print(
+                        f"FAIL  {app}.{name}: wrapper missing {key} "
+                        f"(inner has {key}={inner_val})",
+                        file=sys.stderr,
+                    )
+                    fail_count += 1
+                elif inner_val is None and wrap_val is not None:
+                    print(
+                        f"WARN  {app}.{name}: wrapper has {key}={wrap_val} "
+                        f"but inner has none (wrapper is stricter)",
+                        file=sys.stderr,
+                    )
+                    warn_count += 1
+                else:
+                    print(
+                        f"FAIL  {app}.{name}: {key} mismatch: "
+                        f"inner={inner_val} wrapper={wrap_val}",
+                        file=sys.stderr,
+                    )
+                    fail_count += 1
+
+    if warn_count or fail_count:
+        print(
+            f"\n{warn_count} warning(s), {fail_count} failure(s)",
+            file=sys.stderr,
+        )
+    if fail_count:
+        sys.exit(1)
+    print("OK: stackset parameter constraint parity check passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/embed-lambda-defaults.py
+++ b/scripts/embed-lambda-defaults.py
@@ -55,6 +55,21 @@ def embed_defaults(template_path, defaults):
             new_content = pattern_dq.sub(replacement_dq, content)
 
         if new_content == content:
+            # No Default line exists — insert one after the last indented
+            # property line in the parameter block.
+            insert_pattern = re.compile(
+                r"(^  " + re.escape(param_name) + r":\s*\n"
+                r"(?:    .*\n)*?)"     # capture the full param block
+                r"(?=  \S|\Z)",        # stop at the next top-level key or EOF
+                re.MULTILINE,
+            )
+            match = insert_pattern.search(content)
+            if match:
+                block = match.group(1)
+                new_block = block + "    Default: '" + param_value + "'\n"
+                new_content = content[:match.start()] + new_block + content[match.end():]
+
+        if new_content == content:
             skipped.append(param_name)
 
         content = new_content


### PR DESCRIPTION
## Summary

Stacked on top of #464 (plain-CFN conversion). Adds CloudFormation StackSet wrappers so the logwriter / metricstream / externalrole apps can be deployed across an AWS Organization from a single template.

- **3 stackset wrappers** (`apps/<app>-stackset/template.yaml`) — each wraps the underlying CFN_APP via `AWS::CloudFormation::StackSet` with `SERVICE_MANAGED` permissions, auto-deployment, and parameterised `OperationPreferences` (defaults: 100% concurrent, 100% failure tolerance, parallel regions).
- **Build** — `sam-package` now embeds a region-specific `TemplateURL` default in each stackset wrapper so customers don't have to construct the underlying app's S3 URL. `embed-lambda-defaults.py` gains an "insert Default if missing" branch (TemplateURL has no source-side default). `sam-pull` now downloads stackset templates too.
- **Docs** — `docs/multi-account.md` covers prereqs, central bucket permissions, concurrency tuning, monitoring, partial-failure recovery, and cleanup. DEVELOPER.md gets a StackSet workflow section.

## Test plan

- [ ] CI: `cfn-lint` clean on all 3 stackset wrappers, `yamllint` clean
- [ ] `make sam-package-<app>` produces `<app>-stackset.yaml` with `TemplateURL` default pointing at the just-uploaded `<app>.yaml` in the same bucket+version (verified locally for externalrole)
- [ ] One end-to-end stackset deploy in a test org once #464 lands

## Stacking

Once #464 merges, GitHub will auto-rebase this PR onto main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)