### PR TITLE
docs: add Multi-account deployment pointer to logwriter / metricstream / externalrole

### DIFF
--- a/docs/externalrole.md
+++ b/docs/externalrole.md
@@ -47,3 +47,7 @@ Enabling PollerConfigurator has the net effect of **creating a poller in the Obs
 | Output | Description |
 |--------|-------------|
 | `RoleArn` | IAM role ARN Observe assumes to pull data. Only not emitted when the **`PrimaryRegion`** of the StackSet is different from the region the stack is being deployed in. |
+
+## Multi-account deployment
+
+For deploying ExternalRole across many accounts in an AWS Organization, use the `externalrole-stackset` wrapper template instead of deploying this app directly. The wrapper creates an `AWS::CloudFormation::StackSet` resource that fans out ExternalRole to every account in a target OU. Note: because IAM roles are global, only stack instances where `AWS::Region == PrimaryRegion` actually create the role; other regions skip it. See [docs/multi-account.md](multi-account.md) for the cross-cutting concerns (concurrency, per-instance verification).

--- a/docs/logwriter.md
+++ b/docs/logwriter.md
@@ -189,3 +189,7 @@ Both rules will send requests to the SQS queue, which in turn are consumed by th
 Uninstalling this app will not clean up configured subscription filters. This is because the time required to uninstall subscription filters varies according to the number of log groups. For a sufficient number of log groups the uninstall timeout would be systematically exceeded, making the app uninstall very brittle.
 
 Given the Firehose will be deleted on uninstall, any existing subscription filters which reference the Firehose will have no effect. If you wish to delete these subscription filters, you should delete them prior to uninstall by setting `ExcludeLogGroupMatches` to `*` and updating your stack. This will work because the inclusion filters `LogGroupPrefixes` and `LogGroupPatterns` determine the set of log groups the Subscriber is allowed to operate on, whereas the exclusion set `ExcludeLogGroupMatches` determines the subset of log groups which cannot have our filter set.
+
+## Multi-account deployment
+
+For deploying LogWriter across many accounts in an AWS Organization, use the `logwriter-stackset` wrapper template instead of deploying this app directly. The wrapper creates an `AWS::CloudFormation::StackSet` resource that fans out LogWriter to every account in a target OU. See [docs/multi-account.md](multi-account.md) for the cross-cutting concerns (central bucket policy, concurrency, per-instance verification).

--- a/docs/metricstream.md
+++ b/docs/metricstream.md
@@ -94,3 +94,7 @@ To replicate this behavior, you will need to retrieve a token from Observe. You 
 ```
 
 You will receive a response containing a token. You can then provide this token to the stack as the `GQLToken` parameter.
+
+## Multi-account deployment
+
+For deploying MetricStream across many accounts in an AWS Organization, use the `metricstream-stackset` wrapper template instead of deploying this app directly. The wrapper creates an `AWS::CloudFormation::StackSet` resource that fans out MetricStream to every account in a target OU. See [docs/multi-account.md](multi-account.md) for the cross-cutting concerns (central bucket policy, concurrency, per-instance verification).


### PR DESCRIPTION
## Summary

Discovered while auditing post-merge gaps from #465: the three app docs treated the StackSet variant inconsistently.

- `docs/externalrole.md` had inline "StackSet" mentions only in unrelated contexts (PrimaryRegion behavior, RoleArn emission rules).
- `docs/metricstream.md` had a single inline "StackSets" mention explaining why Lambda is used instead of `AWS::Include`.
- `docs/logwriter.md` had no stackset reference at all.

None linked to `docs/multi-account.md`, the cross-cutting StackSet operations guide.

This PR adds a parallel **Multi-account deployment** section at the end of each app's doc, linking to the corresponding `*-stackset` wrapper and to `multi-account.md`. The externalrole section additionally notes the IAM-role-is-global single-PrimaryRegion behavior so customers deploying that stackset across many regions don't get confused by empty `RoleArn` outputs in non-primary regions.

## Test plan

- [ ] No CI behavior change (docs-only).
- [ ] Render preview in GitHub UI shows the new section in all three docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)